### PR TITLE
Move include for Newton to Cashflow module

### DIFF
--- a/lib/finrb/cashflows.rb
+++ b/lib/finrb/cashflows.rb
@@ -9,11 +9,11 @@ require 'bigdecimal/newton'
 require 'business_time'
 
 module Finrb
-  include Newton
-
   # Provides methods for working with cash flows (collections of transactions)
   # @api public
   module Cashflow
+    include Newton
+
     # Base class for working with Newton's Method.
     # @api private
     class Function


### PR DESCRIPTION
When using xirr on an array of transactions in our Rails app we found that calling the method would raise an exception:

```
NoMethodError:
  undefined method `nlsolve' for an instance of Array
```

It turns out that the Array class is not extended with Newton as the include is within the `Finrb` module, not the `Cashflow` module.

Adding the following patch to our code fixes the issue:

```
class Array
  include Newton
end
```

The Array object is extended, and the call to `xirr` works as expected.

This commit moves the Newton include inside the `Cashflow` module so that when Array is extended on line 173, Newton will be included too.