### PR TITLE
utils.pmt: Prevent float conversion for the result

### DIFF
--- a/lib/finrb/utils.rb
+++ b/lib/finrb/utils.rb
@@ -774,7 +774,7 @@ module Finrb
       if type != 0 && type != 1
         raise(FinrbError, 'Error: type should be 0 or 1!')
       else
-        (pv + (fv / ((r + 1)**n))) * r / (1 - (1.to_f / ((r + 1)**n))) * -1 * ((r + 1)**(type * -1))
+        (pv + (fv / ((r + 1)**n))) * r / (1 - (1 / ((r + 1)**n))) * -1 * ((r + 1)**(type * -1))
       end
     end
 


### PR DESCRIPTION
### Summary

Hello. The result of `Finrb::Utils.pmt` will be of type `DecNum` now instead of `Float`.

I am not sure if there is a reason to keep the result in float or if this was an overlook; but I was expecting the result to be `DecNum`. Explicitly casting `1` to float coerces the whole expression to Float.

Please let me know if there was a reason to explicitly cast `1` to Float instead.

```rb
main(dev)> (pv + (fv / ((r + 1)**n))) * r / (1 - (1.to_f / ((r + 1)**n))) * -1 * ((r + 1)**(type * -1))
=> -249.57113133210495
main(dev)> (pv + (fv / ((r + 1)**n))) * r / (1 - (1 / ((r + 1)**n))) * -1 * ((r + 1)**(type * -1))
=> DecNum('-249.5711313321050743723928652')
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing to finrb! -->
