### PR TITLE
finrb v1.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      rubocop:
+        patterns:
+          - rubocop*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,16 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +34,7 @@ jobs:
   arm64:
     name: Ruby 4.0 on native ARM64
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -41,6 +50,7 @@ jobs:
   alternative_rubies:
     name: ${{ matrix.ruby }} compatibility
     continue-on-error: true
+    timeout-minutes: 30
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/engines.gemfile
     strategy:
@@ -61,6 +71,7 @@ jobs:
         run: bundle exec rspec
 
   docker_build:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -70,3 +81,44 @@ jobs:
       - uses: actions/checkout@v7
       - name: build test docker image
         run: docker build --build-arg RUBY_VER=${{ matrix.ruby_version }} --target testing -t finrb -f Dockerfile .
+
+  package:
+    name: Packaged gem
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FINRB_PACKAGE: ${{ runner.temp }}/finrb.gem
+      FINRB_GEM_HOME: ${{ runner.temp }}/finrb-package-gems
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+      - name: Run quality checks
+        run: bundle exec rake quality
+      - name: Build and inspect gem
+        run: |
+          gem build finrb.gemspec --output "$FINRB_PACKAGE"
+          ruby script/verify_gem.rb "$FINRB_PACKAGE"
+      - name: Install and smoke-test gem
+        run: |
+          mkdir -p "$FINRB_GEM_HOME"
+          GEM_HOME="$FINRB_GEM_HOME" GEM_PATH="$FINRB_GEM_HOME" gem install "$FINRB_PACKAGE" --no-document
+          cd "${{ runner.temp }}"
+          GEM_HOME="$FINRB_GEM_HOME" GEM_PATH="$FINRB_GEM_HOME" ruby "$GITHUB_WORKSPACE/script/smoke_gem.rb"
+
+  dependency_audit:
+    name: Ruby dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+      - name: Check Ruby advisories
+        run: bundle exec bundle-audit check --update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Run tests
         run: bundle exec rake quality
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
     name: Packaged gem
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      FINRB_PACKAGE: ${{ runner.temp }}/finrb.gem
-      FINRB_GEM_HOME: ${{ runner.temp }}/finrb-package-gems
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -112,13 +109,16 @@ jobs:
         run: bundle exec rake quality
       - name: Build and inspect gem
         run: |
+          FINRB_PACKAGE="$RUNNER_TEMP/finrb.gem"
           gem build finrb.gemspec --output "$FINRB_PACKAGE"
           ruby script/verify_gem.rb "$FINRB_PACKAGE"
       - name: Install and smoke-test gem
         run: |
+          FINRB_PACKAGE="$RUNNER_TEMP/finrb.gem"
+          FINRB_GEM_HOME="$RUNNER_TEMP/finrb-package-gems"
           mkdir -p "$FINRB_GEM_HOME"
           GEM_HOME="$FINRB_GEM_HOME" GEM_PATH="$FINRB_GEM_HOME" gem install "$FINRB_PACKAGE" --no-document
-          cd "${{ runner.temp }}"
+          cd "$RUNNER_TEMP"
           GEM_HOME="$FINRB_GEM_HOME" GEM_PATH="$FINRB_GEM_HOME" ruby "$GITHUB_WORKSPACE/script/smoke_gem.rb"
 
   dependency_audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
   alternative_rubies:
     name: ${{ matrix.ruby }} compatibility
     continue-on-error: true
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/engines.gemfile
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,19 @@ jobs:
         run: bundle exec rake quality
 
   arm64:
-    name: Ruby 4.0 on native ARM64
+    name: Ruby ${{ matrix.ruby_version }} on native ARM64
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ["3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
       - name: Report runtime
         run: ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM'
@@ -81,6 +85,25 @@ jobs:
       - uses: actions/checkout@v7
       - name: build test docker image
         run: docker build --build-arg RUBY_VER=${{ matrix.ruby_version }} --target testing -t finrb -f Dockerfile .
+
+  alternative_ruby_docker:
+    name: ${{ matrix.engine }} Docker compatibility
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [jruby, truffleruby]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+      - name: Build and test ${{ matrix.engine }} image
+        run: bundle exec rake docker:${{ matrix.engine }}:test
 
   package:
     name: Packaged gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    timeout-minutes: 15
+  mri:
+    name: Ruby ${{ matrix.ruby_version }} / ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
         ruby_version: ["3.3", "3.4", "4.0"]
-    runs-on: ubuntu-latest
+        target: [x86_64, arm64, docker]
+        include:
+          - target: x86_64
+            runner: ubuntu-latest
+            timeout: 15
+          - target: arm64
+            runner: ubuntu-24.04-arm
+            timeout: 20
+          - target: docker
+            runner: ubuntu-latest
+            timeout: 30
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -28,28 +40,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake quality
-
-  arm64:
-    name: Ruby ${{ matrix.ruby_version }} on native ARM64
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version: ["3.3", "3.4", "4.0"]
-    steps:
-      - uses: actions/checkout@v7
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: Report runtime
+      - name: Report native runtime
+        if: matrix.target != 'docker'
         run: ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM'
-      - name: Run quality checks
+      - name: Run native quality checks
+        if: matrix.target != 'docker'
         run: bundle exec rake quality
+      - name: Build and test Docker image
+        if: matrix.target == 'docker'
+        env:
+          RUBY_VER: ${{ matrix.ruby_version }}
+        run: bundle exec rake docker:test
 
   alternative_rubies:
     name: ${{ matrix.ruby }} compatibility
@@ -73,18 +74,6 @@ jobs:
         run: ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM'
       - name: Run compatibility specs
         run: bundle exec rspec
-
-  docker_build:
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version: ["3.3", "3.4", "4.0"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: build test docker image
-        run: docker build --build-arg RUBY_VER=${{ matrix.ruby_version }} --target testing -t finrb -f Dockerfile .
 
   alternative_ruby_docker:
     name: ${{ matrix.engine }} Docker compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,41 @@ jobs:
       - name: Run tests
         run: bundle exec rake quality
 
+  arm64:
+    name: Ruby 4.0 on native ARM64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+      - name: Report runtime
+        run: ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM'
+      - name: Run quality checks
+        run: bundle exec rake quality
+
+  alternative_rubies:
+    name: ${{ matrix.ruby }} compatibility
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [jruby, truffleruby]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Report runtime
+        run: ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM'
+      - name: Run compatibility specs
+        run: bundle exec rspec
+
   docker_build:
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,10 @@ jobs:
     name: Analyze Ruby
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ruby]
     permissions:
       actions: read
       contents: read
@@ -26,6 +30,6 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.7
         with:
-          languages: ruby
+          languages: ${{ matrix.language }}
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,72 +1,31 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [main]
   schedule:
-    - cron: '34 2 * * 3'
+    - cron: "34 2 * * 3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze Ruby
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'ruby' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.7
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.7
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.7
+      - uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.37.7
+        with:
+          languages: ruby
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4.37.7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,12 +2,17 @@ name: RuboCop
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
 

--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 1
 :minor: 0
-:patch: 0
+:patch: 1
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # finrb changelog
 
+## 1.0.1
+
+### Runtime compatibility
+
+- Test Ruby 3.3, 3.4, and 4.0 across x86-64, native ARM64, and Docker environments.
+- Add experimental JRuby and TruffleRuby compatibility suites and isolated development/test images.
+- Add Docker Buildx tasks for developing and running the ARM64 image on x86-64 hosts.
+- Add version-selectable, failure-aware Docker build, test, and run tasks.
+
+### Packaging and assurance
+
+- Verify gem metadata, packaged licenses, attribution, RBS declarations, and runtime dependencies.
+- Install the built gem into an isolated gem home and smoke-test version loading, NPV, IRR, and opt-in core extensions.
+- Add dependency review, ruby-advisory-db auditing, grouped Dependabot updates, workflow timeouts, and concurrency controls.
+- Simplify CodeQL analysis and add reusable package and security verification tasks.
+- Declare `ostruct` as a runtime dependency because it is required by `flt` and is no longer bundled with Ruby 4.
+
 ## 1.0.0
 
 This release intentionally breaks parts of the 0.1 public API.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENTRYPOINT ["/bin/bash", "-c", "/bin/bash"]
 
 FROM development AS testing
 
-RUN bundle exec rake
+RUN ruby -v && ruby -e 'puts RUBY_DESCRIPTION; puts RUBY_PLATFORM' && bundle exec rake quality
 
 ENTRYPOINT ["/bin/bash", "-c", "/bin/bash"]
 

--- a/Dockerfile.engines
+++ b/Dockerfile.engines
@@ -1,0 +1,28 @@
+ARG RUBY_IMAGE=jruby:10.1-jdk21
+ARG EXPECTED_RUBY_ENGINE=jruby
+
+FROM ${RUBY_IMAGE} AS development
+
+ARG EXPECTED_RUBY_ENGINE
+ENV EXPECTED_RUBY_ENGINE=${EXPECTED_RUBY_ENGINE}
+
+WORKDIR /app
+
+ENV BUNDLE_GEMFILE=/app/gemfiles/engines.gemfile
+
+RUN gem install bundler
+RUN bundle config --global jobs 16
+
+COPY *.gemspec ./
+COPY gemfiles/engines.gemfile ./gemfiles/engines.gemfile
+COPY lib/finrb/version.rb ./lib/finrb/version.rb
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT ["/bin/bash"]
+
+FROM development AS testing
+
+RUN ruby -e 'expected = ENV.fetch("EXPECTED_RUBY_ENGINE"); raise "expected #{expected}, got #{RUBY_ENGINE}" unless RUBY_ENGINE == expected' && \
+  bundle exec rspec

--- a/Dockerfile.engines
+++ b/Dockerfile.engines
@@ -1,4 +1,4 @@
-ARG RUBY_IMAGE=jruby:10.1-jdk21
+ARG RUBY_IMAGE=jruby:10-jdk21
 ARG EXPECTED_RUBY_ENGINE=jruby
 
 FROM ${RUBY_IMAGE} AS development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,9 @@ GEM
     amazing_print (2.0.0)
     ast (2.4.3)
     bigdecimal (4.1.2)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     coderay (1.1.3)
     diff-lcs (1.6.2)
     flt (1.5.4)
@@ -85,6 +88,7 @@ GEM
     ruby-progressbar (1.13.0)
     semver (1.0.1)
     simplecov (1.1.1)
+    thor (1.5.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -96,6 +100,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  bundler-audit
   finrb!
   pry
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    finrb (1.0.0)
+    finrb (1.0.1)
       bigdecimal (>= 3.1.2)
       flt
       ostruct

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     finrb (1.0.0)
       bigdecimal (>= 3.1.2)
       flt
+      ostruct
 
 GEM
   remote: https://rubygems.org/
@@ -96,7 +97,6 @@ PLATFORMS
 DEPENDENCIES
   amazing_print
   finrb!
-  ostruct
   pry
   rake
   rbs

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ bundle exec rake docker:truffleruby:test
 bundle exec rake docker:truffleruby:run
 ```
 
-The defaults track JRuby 10.1 on JDK 21 and the current TruffleRuby Community
+The defaults track JRuby 10 on JDK 21 and the current TruffleRuby Community
 image. Override them with `JRUBY_IMAGE` or `TRUFFLERUBY_IMAGE` when testing a
 specific release. These images use `gemfiles/engines.gemfile`, which contains
 only finrb's runtime dependencies and RSpec; MRI-only development tooling such

--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ The quality task runs the RSpec suite with line and branch coverage, generated
 IRR/XIRR properties, committed SciPy/QuantLib reference fixtures, and RBS
 validation.
 
+CI also runs the quality suite on native ARM64 and compatibility specs on the
+current stable JRuby and TruffleRuby. Alternative Ruby jobs are initially
+informational while their dependency and numerical compatibility is assessed.
+
+On an x86-64 development machine with Docker Buildx and ARM64 emulation
+available, build, test, and run the ARM64 development image with:
+
+```shell
+bundle exec rake docker:arm64:build
+bundle exec rake docker:arm64:test
+bundle exec rake docker:arm64:run
+```
+
+Docker Desktop normally provides the required emulation. A Linux Docker Engine
+installation must have an ARM64-capable Buildx builder and binfmt/QEMU support
+configured by the operator.
+
 Maintainers with the optional Python environment can run the larger seeded
 solver verification campaign:
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,26 @@ Docker Desktop normally provides the required emulation. A Linux Docker Engine
 installation must have an ARM64-capable Buildx builder and binfmt/QEMU support
 configured by the operator.
 
+The alternative Ruby development images share a minimal, package-manager-
+independent Dockerfile. Build, test, and run either implementation with:
+
+```shell
+bundle exec rake docker:jruby:build
+bundle exec rake docker:jruby:test
+bundle exec rake docker:jruby:run
+
+bundle exec rake docker:truffleruby:build
+bundle exec rake docker:truffleruby:test
+bundle exec rake docker:truffleruby:run
+```
+
+The defaults track JRuby 10.1 on JDK 21 and the current TruffleRuby Community
+image. Override them with `JRUBY_IMAGE` or `TRUFFLERUBY_IMAGE` when testing a
+specific release. These images use `gemfiles/engines.gemfile`, which contains
+only finrb's runtime dependencies and RSpec; MRI-only development tooling such
+as RBS, RuboCop, and coverage is deliberately excluded from engine
+compatibility runs.
+
 Maintainers with the optional Python environment can run the larger seeded
 solver verification campaign:
 

--- a/README.md
+++ b/README.md
@@ -208,11 +208,18 @@ Install the bundle and run the self-contained quality checks:
 bundle install
 bundle exec rake quality
 bundle exec rubocop
+bundle exec rake security:audit
+bundle exec rake package:verify
 ```
 
 The quality task runs the RSpec suite with line and branch coverage, generated
 IRR/XIRR properties, committed SciPy/QuantLib reference fixtures, and RBS
 validation.
+
+`security:audit` updates ruby-advisory-db and checks the locked dependencies.
+`package:verify` builds the gem, validates its contents and metadata, installs
+it with only its declared runtime dependencies, and runs packaged API smoke
+tests without publishing or retaining the temporary installation.
 
 CI also runs the quality suite on native ARM64 and compatibility specs on the
 current stable JRuby and TruffleRuby. Alternative Ruby jobs are initially

--- a/README.md
+++ b/README.md
@@ -221,9 +221,18 @@ validation.
 it with only its declared runtime dependencies, and runs packaged API smoke
 tests without publishing or retaining the temporary installation.
 
-CI also runs the quality suite on native ARM64 and compatibility specs on the
-current stable JRuby and TruffleRuby. Alternative Ruby jobs are initially
-informational while their dependency and numerical compatibility is assessed.
+CI runs every supported MRI version on x86-64, native ARM64, and Docker, plus
+compatibility specs and Docker builds for the current stable JRuby and
+TruffleRuby. Alternative Ruby jobs are initially informational while their
+dependency and numerical compatibility is assessed.
+
+Select the MRI version used by the ordinary Docker tasks with `RUBY_VER`:
+
+```shell
+RUBY_VER=3.3 bundle exec rake docker:build
+RUBY_VER=3.3 bundle exec rake docker:test
+RUBY_VER=3.3 bundle exec rake docker:run
+```
 
 On an x86-64 development machine with Docker Buildx and ARM64 emulation
 available, build, test, and run the ARM64 development image with:

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,42 @@ namespace :rbs do
   end
 end
 
+namespace :security do
+  desc 'Update ruby-advisory-db and audit locked dependencies'
+  task :audit do
+    sh('bundle', 'exec', 'bundle-audit', 'check', '--update')
+  end
+end
+
+namespace :package do
+  desc 'Build, inspect, install, and smoke-test the gem without publishing it'
+  task :verify do
+    require('bundler')
+    require('fileutils')
+    require('rbconfig')
+
+    scratch_dir = File.expand_path('tmp/finrb-package-verification', __dir__)
+    artifact = File.join(scratch_dir, 'finrb.gem')
+    gem_home = File.join(scratch_dir, 'gems')
+    gem_environment = { gem_home:, gem_path: gem_home }.transform_keys { |key| key.to_s.upcase }
+
+    FileUtils.rm_rf(scratch_dir)
+    FileUtils.mkdir_p(gem_home)
+
+    sh('gem', 'build', 'finrb.gemspec', '--output', artifact)
+    sh(RbConfig.ruby, File.join(__dir__, 'script', 'verify_gem.rb'), artifact)
+    Bundler.with_unbundled_env do
+      sh(gem_environment, 'gem', 'install', artifact, '--no-document')
+
+      Dir.chdir(scratch_dir) do
+        sh(gem_environment, RbConfig.ruby, File.join(__dir__, 'script', 'smoke_gem.rb'))
+      end
+    end
+  ensure
+    FileUtils.rm_rf(scratch_dir) if defined?(scratch_dir) && scratch_dir
+  end
+end
+
 namespace :solver do
   desc 'Verify IRR/XIRR against SciPy and QuantLib references'
   task :verify do

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,13 @@ namespace :solver do
 end
 
 namespace :docker do
+  alternative_dockerfile = 'Dockerfile.engines'
+  alternative_images = { jruby: ENV.fetch('JRUBY_IMAGE', 'jruby:10.1-jdk21'), truffleruby: ENV.fetch('TRUFFLERUBY_IMAGE', 'ghcr.io/graalvm/truffleruby-community:latest') }
+  build_alternative =
+    lambda do |engine, target, tag|
+      sh('docker', 'build', '--build-arg', "RUBY_IMAGE=#{alternative_images.fetch(engine)}", '--build-arg', "EXPECTED_RUBY_ENGINE=#{engine}", '--target', target, '--tag', tag, '--file', alternative_dockerfile, '.')
+    end
+
   desc 'Build docker instance'
   task :build do
     Dir.chdir(__dir__.to_s) do
@@ -67,6 +74,40 @@ namespace :docker do
     desc 'Run the ARM64 development image on this Docker host'
     task :run do
       sh('docker', 'run', '--platform', 'linux/arm64', '--init', '--interactive', '--tty', '--rm', 'finrb:1.0-arm64')
+    end
+  end
+
+  namespace :jruby do
+    desc 'Build the JRuby development image'
+    task :build do
+      build_alternative.call(:jruby, 'development', 'finrb:jruby')
+    end
+
+    desc 'Build finrb and run its specs on JRuby'
+    task :test do
+      build_alternative.call(:jruby, 'testing', 'finrb:jruby-testing')
+    end
+
+    desc 'Run the JRuby development image'
+    task :run do
+      sh('docker', 'run', '--init', '--interactive', '--tty', '--rm', 'finrb:jruby')
+    end
+  end
+
+  namespace :truffleruby do
+    desc 'Build the TruffleRuby development image'
+    task :build do
+      build_alternative.call(:truffleruby, 'development', 'finrb:truffleruby')
+    end
+
+    desc 'Build finrb and run its specs on TruffleRuby'
+    task :test do
+      build_alternative.call(:truffleruby, 'testing', 'finrb:truffleruby-testing')
+    end
+
+    desc 'Run the TruffleRuby development image'
+    task :run do
+      sh('docker', 'run', '--init', '--interactive', '--tty', '--rm', 'finrb:truffleruby')
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ end
 
 namespace :docker do
   alternative_dockerfile = 'Dockerfile.engines'
-  alternative_images = { jruby: ENV.fetch('JRUBY_IMAGE', 'jruby:10.1-jdk21'), truffleruby: ENV.fetch('TRUFFLERUBY_IMAGE', 'ghcr.io/graalvm/truffleruby-community:latest') }
+  alternative_images = { jruby: ENV.fetch('JRUBY_IMAGE', 'jruby:10-jdk21'), truffleruby: ENV.fetch('TRUFFLERUBY_IMAGE', 'ghcr.io/graalvm/truffleruby-community:latest') }
   build_alternative =
     lambda do |engine, target, tag|
       sh('docker', 'build', '--build-arg', "RUBY_IMAGE=#{alternative_images.fetch(engine)}", '--build-arg', "EXPECTED_RUBY_ENGINE=#{engine}", '--target', target, '--tag', tag, '--file', alternative_dockerfile, '.')

--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,23 @@ namespace :docker do
     end
   end
 
+  namespace :arm64 do
+    desc 'Build an ARM64 development image with Docker Buildx'
+    task :build do
+      sh('docker', 'buildx', 'build', '--platform', 'linux/arm64', '--target', 'development', '--tag', 'finrb:1.0-arm64', '--load', '--file', 'Dockerfile', '.')
+    end
+
+    desc 'Run the quality suite in an emulated ARM64 Docker build'
+    task :test do
+      sh('docker', 'buildx', 'build', '--platform', 'linux/arm64', '--target', 'testing', '--tag', 'finrb:testing-arm64', '--load', '--file', 'Dockerfile', '.')
+    end
+
+    desc 'Run the ARM64 development image on this Docker host'
+    task :run do
+      sh('docker', 'run', '--platform', 'linux/arm64', '--init', '--interactive', '--tty', '--rm', 'finrb:1.0-arm64')
+    end
+  end
+
   desc 'Build and run solver reference verification in Docker'
   task :verify_solver do
     image = 'finrb:solver-verification'

--- a/Rakefile
+++ b/Rakefile
@@ -84,15 +84,17 @@ namespace :docker do
 
   desc 'Build docker instance'
   task :build do
-    Dir.chdir(__dir__.to_s) do
-      system 'docker build --target development -t finrb:1.0 -f Dockerfile .'
+    ruby_version = ENV.fetch('RUBY_VER', '4.0')
+    Dir.chdir(__dir__) do
+      sh('docker', 'build', '--build-arg', "RUBY_VER=#{ruby_version}", '--target', 'development', '--tag', "finrb:ruby-#{ruby_version}", '--file', 'Dockerfile', '.')
     end
   end
 
   desc 'Run test docker build'
   task :test do
-    Dir.chdir(__dir__.to_s) do
-      system 'docker build --target testing -t finrb:1.0 -f Dockerfile .'
+    ruby_version = ENV.fetch('RUBY_VER', '4.0')
+    Dir.chdir(__dir__) do
+      sh('docker', 'build', '--build-arg', "RUBY_VER=#{ruby_version}", '--target', 'testing', '--tag', "finrb:ruby-#{ruby_version}-testing", '--file', 'Dockerfile', '.')
     end
   end
 
@@ -161,6 +163,7 @@ namespace :docker do
 
   desc 'Run dev docker instance'
   task :run do
-    system 'docker run --init -it --rm finrb:1.0'
+    ruby_version = ENV.fetch('RUBY_VER', '4.0')
+    sh('docker', 'run', '--init', '--interactive', '--tty', '--rm', "finrb:ruby-#{ruby_version}")
   end
 end

--- a/finrb.gemspec
+++ b/finrb.gemspec
@@ -25,9 +25,9 @@ SPEC =
 
     s.add_dependency('bigdecimal', '>= 3.1.2')
     s.add_dependency('flt')
+    s.add_dependency('ostruct')
 
     s.add_development_dependency('amazing_print')
-    s.add_development_dependency('ostruct')
     s.add_development_dependency('pry')
     s.add_development_dependency('rake')
     s.add_development_dependency('rbs')

--- a/finrb.gemspec
+++ b/finrb.gemspec
@@ -28,6 +28,7 @@ SPEC =
     s.add_dependency('ostruct')
 
     s.add_development_dependency('amazing_print')
+    s.add_development_dependency('bundler-audit')
     s.add_development_dependency('pry')
     s.add_development_dependency('rake')
     s.add_development_dependency('rbs')

--- a/gemfiles/engines.gemfile
+++ b/gemfiles/engines.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Gem under compatibility test, with runtime dependencies only.
+gem 'finrb', path: '..'
+# Test runner supported across the selected Ruby implementations.
+gem 'rspec', '~> 3.13'

--- a/lib/finrb/version.rb
+++ b/lib/finrb/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Finrb
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
   public_constant :VERSION
 end

--- a/script/smoke_gem.rb
+++ b/script/smoke_gem.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'finrb'
+
+loaded_version = Gem.loaded_specs.fetch('finrb').version.to_s
+abort("Expected finrb #{loaded_version}, loaded #{Finrb::VERSION}") unless loaded_version == Finrb::VERSION
+abort('Core extensions loaded by default') if [].respond_to?(:irr)
+
+cashflows = [-4000, 1200, 1410, 1875, 1050]
+npv = Finrb::Cashflow.npv(cashflows, 0.10).round(2)
+irr = Finrb::Cashflow.irr(cashflows).round(6)
+abort("Unexpected NPV: #{npv}") unless npv == Flt::DecNum('382.08')
+abort("Unexpected IRR: #{irr}") unless irr == Flt::DecNum('0.142993')
+
+require 'finrb/core_ext'
+
+abort('Core extensions unavailable after explicit require') unless [].respond_to?(:irr)

--- a/script/verify_gem.rb
+++ b/script/verify_gem.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rubygems/package'
+require_relative '../lib/finrb/version'
+
+package_path = ARGV.fetch(0)
+package = Gem::Package.new(package_path)
+specification = package.spec
+
+required_files = %w[CHANGELOG.md COPYING COPYING.LESSER NOTICE.md README.md lib/finrb.rb lib/finrb/version.rb sig/finrb.rbs]
+missing_files = required_files - specification.files
+raise(Gem::InvalidSpecificationException, "Gem is missing packaged files: #{missing_files.join(', ')}") unless missing_files.empty?
+
+required_metadata = %w[bug_tracker_uri changelog_uri documentation_uri rubygems_mfa_required source_code_uri]
+missing_metadata =
+  required_metadata.reject do |key|
+    value = specification.metadata.fetch(key, '')
+    key == 'rubygems_mfa_required' ? value == 'true' : value.start_with?('https://')
+  end
+raise(Gem::InvalidSpecificationException, "Gem has missing or invalid metadata: #{missing_metadata.join(', ')}") unless missing_metadata.empty?
+
+runtime_dependencies = specification.runtime_dependencies.map(&:name)
+missing_dependencies = %w[bigdecimal flt ostruct] - runtime_dependencies
+raise(Gem::InvalidSpecificationException, "Gem is missing runtime dependencies: #{missing_dependencies.join(', ')}") unless missing_dependencies.empty?
+
+raise(Gem::InvalidSpecificationException, "Gem version #{specification.version} does not match #{Finrb::VERSION}") unless specification.version.to_s == Finrb::VERSION

--- a/spec/finrb_spec.rb
+++ b/spec/finrb_spec.rb
@@ -2,7 +2,7 @@
 
 describe(Finrb) do
   it('exposes the gem version') do
-    expect(described_class::VERSION).to(eq('1.0.0'))
+    expect(described_class::VERSION).to(eq('1.0.1'))
   end
 
   describe('decimal interoperability') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,10 +31,8 @@ start_coverage.call
 # it.
 #
 
-require('amazing_print')
 require('flt')
 require('flt/d')
-require('pry')
 require_relative('../lib/finrb')
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
## 1.0.1

### Runtime compatibility

- Test Ruby 3.3, 3.4, and 4.0 across x86-64, native ARM64, and Docker environments.
- Add experimental JRuby and TruffleRuby compatibility suites and isolated development/test images.
- Add Docker Buildx tasks for developing and running the ARM64 image on x86-64 hosts.
- Add version-selectable, failure-aware Docker build, test, and run tasks.

### Packaging and assurance

- Verify gem metadata, packaged licenses, attribution, RBS declarations, and runtime dependencies.
- Install the built gem into an isolated gem home and smoke-test version loading, NPV, IRR, and opt-in core extensions.
- Add dependency review, ruby-advisory-db auditing, grouped Dependabot updates, workflow timeouts, and concurrency controls.
- Simplify CodeQL analysis and add reusable package and security verification tasks.
- Declare `ostruct` as a runtime dependency because it is required by `flt` and is no longer bundled with Ruby 4.