### PR TITLE
finrb v1.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,9 @@ Bundler/GemVersion:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   Severity: info
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,13 +26,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 26
 
-# Existing utility implementations retained during domain extraction.
-Metrics/ModuleLength:
-  Exclude:
-    - 'lib/finrb/accounting.rb'
-    - 'lib/finrb/cashflows.rb'
-    - 'lib/finrb/ratios.rb'
-
 # Offense count: 5
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:

--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 1
-:minor: 0
-:patch: 1
+:minor: 1
+:patch: 0
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # finrb changelog
 
+## 1.1.0
+
+### Investment returns and risk
+
+- Add compound annual growth rate (CAGR) with explicit value and period-domain validation.
+- Add modified internal rate of return (MIRR) with separate financing and reinvestment rates.
+- Add sample and population volatility, downside deviation, Sortino ratio, and maximum drawdown.
+- Add compound-return and square-root-of-time volatility annualization helpers.
+- Define the statistical conventions explicitly: volatility is sample-based by default, downside deviation includes all observations in its denominator, and maximum drawdown is returned as a non-negative loss fraction.
+
+### Loan schedules
+
+- Expose each amortization period as an immutable `Finrb::Amortization::Entry` containing its period, opening and closing balances, payment, interest, principal, additional principal, balloon settlement, and interest-only state.
+- Preserve the existing cashflow convention: payments are negative, while balances, interest, principal repaid, and additional principal are non-negative.
+- Add contractual balloon targets. Regular installments amortize toward the target and the final payment settles the residual, including cent-rounding reconciliation.
+- Add leading interest-only periods, including zero-rate periods and combinations with balloon loans. Remaining principal amortizes over the rest of the term.
+- Add upfront and financed origination fees with separate `principal`, `net_proceeds`, and `amount_financed` values. Financed fees enter the opening balance; upfront fees reduce borrower proceeds.
+- Correct schedule period numbering across rate segments and reused payment templates.
+
+### API and documentation
+
+- Add RBS declarations and API examples for all new return metrics and amortization features.
+- Refine README compatibility badges to identify tested MRI versions, x86-64/ARM64 architectures, and experimental JRuby/TruffleRuby coverage.
+- Remove redundant YARD `@api` annotations and make the internal amortization calculation methods genuinely private.
+
 ## 1.0.1
 
 ### Runtime compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    finrb (1.0.1)
+    finrb (1.1.0)
       bigdecimal (>= 3.1.2)
       flt
       ostruct

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ loan = Finrb::Amortization.new(250_000, rate)
 loan.payment      # => Flt::DecNum('-1229.85')
 loan.interest.sum # => Flt::DecNum('192745.98')
 loan.balance      # => Flt::DecNum('0.00')
+
+first = loan.schedule.first
+first.opening_balance
+first.interest
+first.principal
+first.payment
+first.closing_balance
 ```
 
 Pass several duration-bearing rates for an adjustable-rate schedule. A block
@@ -133,6 +140,8 @@ end
 
 Payments and interest follow the sign convention used throughout finrb:
 money received is positive and money paid is negative.
+Schedule balances, interest, principal repaid, and additional principal are
+non-negative; the schedule's payment field is negative.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ first.opening_balance
 first.interest
 first.principal
 first.payment
+first.balloon_payment
 first.closing_balance
 ```
 
@@ -142,6 +143,15 @@ Payments and interest follow the sign convention used throughout finrb:
 money received is positive and money paid is negative.
 Schedule balances, interest, principal repaid, and additional principal are
 non-negative; the schedule's payment field is negative.
+
+Set a residual principal target to create a balloon loan. Regular installments
+amortize only the non-balloon portion, and the final payment settles the stated
+balloon:
+
+```ruby
+balloon_loan = Finrb::Amortization.new(250_000, rate, balloon: 100_000)
+balloon_loan.schedule.last.balloon_payment # => Flt::DecNum('100000')
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ interest_only.schedule.first.interest_only? # => true
 interest_only.schedule.first.principal      # => Flt::DecNum('0')
 ```
 
+Origination fees can either reduce the borrower's net proceeds or be added to
+the financed balance:
+
+```ruby
+cash_fee = Finrb::Amortization.new(250_000, rate, origination_fee: 2_500)
+cash_fee.net_proceeds    # => Flt::DecNum('247500')
+cash_fee.amount_financed # => Flt::DecNum('250000')
+
+financed_fee = Finrb::Amortization.new(
+  250_000,
+  rate,
+  origination_fee: 2_500,
+  finance_origination_fee: true
+)
+financed_fee.net_proceeds    # => Flt::DecNum('250000')
+financed_fee.amount_financed # => Flt::DecNum('252500')
+```
+
 ## Configuration
 
 Configure process-wide defaults during application startup:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ first.interest
 first.principal
 first.payment
 first.balloon_payment
+first.interest_only?
 first.closing_balance
 ```
 
@@ -151,6 +152,19 @@ balloon:
 ```ruby
 balloon_loan = Finrb::Amortization.new(250_000, rate, balloon: 100_000)
 balloon_loan.schedule.last.balloon_payment # => Flt::DecNum('100000')
+```
+
+`balloon` is the contractual residual target. Because regular postings are
+rounded to cents, the actual `balloon_payment` in the final schedule row can
+differ from that target by a few cents.
+
+Leading interest-only periods defer scheduled principal repayment and amortize
+the balance over the remaining term:
+
+```ruby
+interest_only = Finrb::Amortization.new(250_000, rate, interest_only_periods: 24)
+interest_only.schedule.first.interest_only? # => true
+interest_only.schedule.first.principal      # => Flt::DecNum('0')
 ```
 
 ## Configuration

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,6 +135,33 @@ loan.schedule.first.interest_only? # => true
 loan.schedule.first.principal      # => Flt::DecNum('0')
 ```
 
+Origination fees are kept separate from interest and principal. By default the
+fee is paid from the loan proceeds, reducing the cash available to the borrower
+without changing scheduled payments:
+
+```ruby
+loan = Finrb::Amortization.new(250_000, rate, origination_fee: 2_500)
+loan.principal        # => Flt::DecNum('250000')
+loan.net_proceeds     # => Flt::DecNum('247500')
+loan.amount_financed  # => Flt::DecNum('250000')
+```
+
+With `finance_origination_fee: true`, the borrower receives the stated
+principal and the fee is added to the opening balance:
+
+```ruby
+loan = Finrb::Amortization.new(
+  250_000,
+  rate,
+  origination_fee: 2_500,
+  finance_origination_fee: true
+)
+
+loan.net_proceeds                    # => Flt::DecNum('250000')
+loan.amount_financed                 # => Flt::DecNum('252500')
+loan.schedule.first.opening_balance  # => Flt::DecNum('252500')
+```
+
 Find the standard monthly payment:
 
 ```ruby

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,6 +90,7 @@ entry.interest
 entry.principal
 entry.additional_payment
 entry.balloon_payment
+entry.interest_only?
 entry.closing_balance
 ```
 
@@ -112,6 +113,26 @@ balloon_loan = Finrb::Amortization.new(250_000, rate, balloon: 100_000)
 balloon_loan.payment
 balloon_loan.schedule.last.balloon_payment # => Flt::DecNum('100000')
 balloon_loan.balance                       # => Flt::DecNum('0')
+```
+
+`balloon` retains the contractual residual target. Since regular payments are
+rounded to cents, the final row's actual `balloon_payment` can differ from the
+target by a small rounding remainder.
+
+Leading interest-only periods pay accrued interest without scheduled principal
+and then amortize the balance over the remaining periods. They can be combined
+with a balloon:
+
+```ruby
+loan = Finrb::Amortization.new(
+  250_000,
+  rate,
+  interest_only_periods: 24,
+  balloon: 50_000
+)
+
+loan.schedule.first.interest_only? # => true
+loan.schedule.first.principal      # => Flt::DecNum('0')
 ```
 
 Find the standard monthly payment:

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,7 @@
 
 - [Amortization](#amortization)
 - [IRR and XIRR](#irr-and-xirr)
+  - [Modified internal rate of return](#modified-internal-rate-of-return)
 - [Financial calculations](#financial-calculations)
   - [Computing bank discount yield BDY for a T-bill](#computing-bank-discount-yield-bdy-for-a-t-bill)
   - [Computing money market yield MMY for a T-bill](#computing-money-market-yield-mmy-for-a-t-bill)
@@ -27,6 +28,7 @@
   - [Estimate future value fv of a single sum](#estimate-future-value-fv-of-a-single-sum)
   - [Computing the future value of an uneven cash flow series](#computing-the-future-value-of-an-uneven-cash-flow-series)
   - [Compound annual growth rate](#compound-annual-growth-rate)
+  - [Risk and annualization helpers](#risk-and-annualization-helpers)
   - [Geometric mean return](#geometric-mean-return)
   - [Gross profit margin - Evaluate a company's financial performance](#gross-profit-margin---evaluate-a-companys-financial-performance)
   - [Harmonic mean, average price](#harmonic-mean-average-price)
@@ -209,6 +211,24 @@ measured from the first transaction. Supply them chronologically, with every
 transaction having a `Date`, `Time`, or another date value that responds to
 `to_date`. As with `irr`, the amounts must contain both signs. Valid discrete
 rates are greater than `-1` (greater than -100%).
+
+### Modified internal rate of return
+
+MIRR avoids IRR's implicit assumption that every intermediate inflow is
+reinvested at the computed IRR. It discounts negative cashflows using the
+financing rate and compounds positive cashflows using the reinvestment rate:
+
+```ruby
+Finrb::Cashflow.mirr(
+  [-100, 39, 59, 55, 20],
+  finance_rate: 0.10,
+  reinvestment_rate: 0.12
+)
+# => Flt::DecNum('0.204376...')
+```
+
+Cashflows are equally spaced and must contain at least one positive and one
+negative amount. Both rates must be greater than `-1`.
 
 ### Guess and multiple roots
 
@@ -752,6 +772,36 @@ Finrb::Returns.cagr(
 
 The beginning value must be positive and the ending value cannot be negative.
 An ending value of zero returns `-1`, representing a total loss.
+
+### Risk and annualization helpers
+
+`volatility` uses sample standard deviation by default; pass `sample: false`
+for population volatility. Downside deviation is the root mean square of
+shortfalls below the target and includes every observation in its denominator.
+
+```ruby
+returns = [-0.10, 0.05, -0.05]
+
+Finrb::Returns.volatility(returns: returns)
+Finrb::Returns.downside_deviation(returns: returns, target: 0)
+Finrb::Returns.sortino_ratio(returns: returns, target: 0)
+Finrb::Returns.sortino_ratio(returns: returns, target: 0, periods_per_year: 12)
+```
+
+Annual returns compound, while volatility uses square-root-of-time scaling:
+
+```ruby
+Finrb::Returns.annualize_return(rate: 0.01, periods_per_year: 12)
+Finrb::Returns.annualize_volatility(volatility: 0.02, periods_per_year: 252)
+```
+
+Maximum drawdown accepts positive portfolio values and returns the largest
+peak-to-trough loss as a non-negative fraction:
+
+```ruby
+Finrb::Returns.max_drawdown(values: [100, 120, 90, 150, 105])
+# => Flt::DecNum('0.3')
+```
 
 ### Geometric mean return
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,6 +78,31 @@ rate = Finrb::Rate.new(0.0425, :apr, :duration => (30 * 12))
 amortization = Finrb::Amortization.new(250000, rate)
 ```
 
+The immutable schedule exposes the accounting breakdown for each period:
+
+```ruby
+entry = amortization.schedule.first
+
+entry.period
+entry.opening_balance
+entry.payment
+entry.interest
+entry.principal
+entry.additional_payment
+entry.closing_balance
+```
+
+Payments use finrb's negative cash-outflow convention. The other monetary
+fields are non-negative. Consequently, every row satisfies:
+
+```text
+opening_balance + interest + payment = closing_balance
+opening_balance - principal = closing_balance
+```
+
+The schedule array and every `Finrb::Amortization::Entry` are frozen. Final
+payment reconciliation is reflected in the last row.
+
 Find the standard monthly payment:
 
 ```ruby

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,7 @@
   - [Estimate future value of an annuity](#estimate-future-value-of-an-annuity)
   - [Estimate future value fv of a single sum](#estimate-future-value-fv-of-a-single-sum)
   - [Computing the future value of an uneven cash flow series](#computing-the-future-value-of-an-uneven-cash-flow-series)
+  - [Compound annual growth rate](#compound-annual-growth-rate)
   - [Geometric mean return](#geometric-mean-return)
   - [Gross profit margin - Evaluate a company's financial performance](#gross-profit-margin---evaluate-a-companys-financial-performance)
   - [Harmonic mean, average price](#harmonic-mean-average-price)
@@ -734,6 +735,23 @@ Examples:
 ```ruby
 Finrb::TVM.fv_uneven(r=0.1, cf=[-1000, -500, 0, 4000, 3500, 2000])
 ```
+
+### Compound annual growth rate
+
+CAGR expresses the constant annual rate that compounds a beginning value into
+an ending value over a positive integer number of equal annual periods.
+
+```ruby
+Finrb::Returns.cagr(
+  beginning_value: 10_000,
+  ending_value: 16_105.10,
+  periods: 5
+)
+# => Flt::DecNum('0.1')
+```
+
+The beginning value must be positive and the ending value cannot be negative.
+An ending value of zero returns `-1`, representing a total loss.
 
 ### Geometric mean return
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,6 +89,7 @@ entry.payment
 entry.interest
 entry.principal
 entry.additional_payment
+entry.balloon_payment
 entry.closing_balance
 ```
 
@@ -102,6 +103,16 @@ opening_balance - principal = closing_balance
 
 The schedule array and every `Finrb::Amortization::Entry` are frozen. Final
 payment reconciliation is reflected in the last row.
+
+A balloon is a residual principal target used when calculating regular
+installments and then settled as part of the final payment:
+
+```ruby
+balloon_loan = Finrb::Amortization.new(250_000, rate, balloon: 100_000)
+balloon_loan.payment
+balloon_loan.schedule.last.balloon_payment # => Flt::DecNum('100000')
+balloon_loan.balance                       # => Flt::DecNum('0')
+```
 
 Find the standard monthly payment:
 

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -24,12 +24,12 @@ module Finrb
     # cashflow sign convention and are negative; the other monetary fields are
     # non-negative.
     class Entry
-      ATTRIBUTES = %i[period opening_balance payment interest principal additional_payment closing_balance].freeze
+      ATTRIBUTES = %i[period opening_balance payment interest principal additional_payment balloon_payment closing_balance].freeze
       private_constant :ATTRIBUTES
 
       attr_reader(*ATTRIBUTES)
 
-      def initialize(period:, opening_balance:, payment:, interest:, principal:, additional_payment:, closing_balance:)
+      def initialize(period:, opening_balance:, payment:, interest:, principal:, additional_payment:, balloon_payment:, closing_balance:)
         raise(ArgumentError, 'period must be a non-negative integer.') unless period.is_a?(Integer) && !period.negative?
 
         @period = period
@@ -58,6 +58,9 @@ module Finrb
     # @return [Flt::DecNum] the balance of the loan at the end of the amortization period (usually zero)
     # @api public
     attr_reader :balance
+    # @return [Flt::DecNum] contractual principal settled as a balloon in the final period
+    # @api public
+    attr_reader :balloon
     # @return [Flt::DecNum] the required monthly payment.  For loans with more than one rate, returns nil
     # @api public
     attr_reader :payment
@@ -82,9 +85,12 @@ module Finrb
     #   Amortization.payment(200000, rate.monthly, rate.duration) #=> Flt::DecNum('-926.23')
     # @see https://en.wikipedia.org/wiki/Amortization_calculator
     # @api public
-    def self.payment(principal, rate, periods)
+    def self.payment(principal, rate, periods, balloon: 0)
       principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless principal.positive?
+
+      balloon = Validation.decimal(balloon, name: 'balloon')
+      raise(ArgumentError, 'balloon must be non-negative and no greater than principal.') unless balloon.between?(0, principal)
 
       rate = Validation.decimal(rate, name: 'rate')
       raise(ArgumentError, 'periodic rate must be greater than -1.') if rate <= -1
@@ -93,9 +99,10 @@ module Finrb
 
       if rate.zero?
         # simplified formula to avoid division-by-zero when interest rate is zero
-        -Precision.money(principal / periods)
+        -Precision.money((principal - balloon) / periods)
       else
-        -Precision.money(principal * (rate + (rate / (((rate + 1)**periods) - 1))))
+        growth = (rate + 1)**periods
+        -Precision.money(((principal * growth) - balloon) * rate / (growth - 1))
       end
     end
 
@@ -105,9 +112,12 @@ module Finrb
     # @param [Rate] rates the applicable interest rates
     # @param [Proc] block
     # @api public
-    def initialize(principal, *rates, &block)
+    def initialize(principal, *rates, balloon: 0, &block)
       @principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless @principal.positive?
+
+      @balloon = Validation.decimal(balloon, name: 'balloon')
+      raise(ArgumentError, 'balloon must be non-negative and less than principal.') if @balloon.negative? || @balloon >= @principal
       raise(ArgumentError, 'at least one rate is required.') if rates.empty?
       raise(ArgumentError, 'rates must be Finrb::Rate instances.') unless rates.all?(Rate)
       raise(ArgumentError, 'every rate must have a duration.') if rates.any? { |rate| rate.duration.nil? }
@@ -127,7 +137,7 @@ module Finrb
     # @param [Amortization] other
     # @api public
     def ==(other)
-      (principal == other.principal) && (rates == other.rates) && (payments == other.payments)
+      (principal == other.principal) && (balloon == other.balloon) && (rates == other.rates) && (payments == other.payments)
     end
 
     # @return [Array] the amount of any additional payments in each period
@@ -149,7 +159,7 @@ module Finrb
       # period is the remaining number of periods in the loan, not
       # necessarily the duration of the rate itself.
       periods = @periods - @period
-      amount = Amortization.payment(@balance, rate.monthly, periods)
+      amount = Amortization.payment(@balance, rate.monthly, periods, balloon: @balloon)
 
       pmt = Payment.new(amount, period: @period)
       pmt.modify(&@block) if @block
@@ -187,8 +197,10 @@ module Finrb
         amortize(rate)
       end
 
-      # Add any remaining balance due to rounding error to the last payment.
+      # Add the residual balloon and any rounding remainder to the last payment.
+      @balloon_by_period = Array.new(@additional_by_period.length, Flt::DecNum(0))
       if @balance.nonzero?
+        @balloon_by_period[-1] = [@balloon, @balance].min
         @transactions.reverse.find(&:payment?).amount -= @balance
         @balance = 0
       end
@@ -197,6 +209,7 @@ module Finrb
 
       @transactions.freeze
       @additional_by_period.freeze
+      @balloon_by_period.freeze
       @schedule = build_schedule.freeze
     end
 
@@ -250,7 +263,7 @@ module Finrb
       @transactions.each_slice(2).with_index.map do |(interest, payment), index|
         principal = -(payment.amount + interest.amount)
         closing_balance = opening_balance - principal
-        entry = Entry.new(period: payment.period, opening_balance:, payment: payment.amount, interest: interest.amount, principal:, additional_payment: @additional_by_period.fetch(index), closing_balance:)
+        entry = Entry.new(period: payment.period, opening_balance:, payment: payment.amount, interest: interest.amount, principal:, additional_payment: @additional_by_period.fetch(index), balloon_payment: @balloon_by_period.fetch(index), closing_balance:)
         opening_balance = closing_balance
         entry
       end

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -23,16 +23,19 @@ module Finrb
     # cashflow sign convention and are negative; the other monetary fields are
     # non-negative.
     class Entry
-      ATTRIBUTES = %i[period opening_balance payment interest principal additional_payment balloon_payment closing_balance].freeze
-      private_constant :ATTRIBUTES
+      ATTRIBUTES = %i[period opening_balance payment interest principal additional_payment balloon_payment interest_only closing_balance].freeze
+      MONETARY_ATTRIBUTES = ATTRIBUTES - %i[period interest_only]
+      private_constant :ATTRIBUTES, :MONETARY_ATTRIBUTES
 
       attr_reader(*ATTRIBUTES)
 
-      def initialize(period:, opening_balance:, payment:, interest:, principal:, additional_payment:, balloon_payment:, closing_balance:)
+      def initialize(period:, opening_balance:, payment:, interest:, principal:, additional_payment:, balloon_payment:, interest_only:, closing_balance:)
         raise(ArgumentError, 'period must be a non-negative integer.') unless period.is_a?(Integer) && !period.negative?
+        raise(ArgumentError, 'interest_only must be true or false.') unless [true, false].include?(interest_only)
 
         @period = period
-        ATTRIBUTES.drop(1).each do |name|
+        @interest_only = interest_only
+        MONETARY_ATTRIBUTES.each do |name|
           value = binding.local_variable_get(name)
           instance_variable_set("@#{name}", Validation.decimal(value, name: name.to_s))
         end
@@ -52,12 +55,16 @@ module Finrb
       def to_h
         ATTRIBUTES.to_h { |name| [name, public_send(name)] }
       end
+
+      alias interest_only? interest_only
     end
 
     # @return [Flt::DecNum] the balance of the loan at the end of the amortization period (usually zero)
     attr_reader :balance
     # @return [Flt::DecNum] contractual principal settled as a balloon in the final period
     attr_reader :balloon
+    # @return [Integer] number of leading periods that pay interest but no scheduled principal
+    attr_reader :interest_only_periods
     # @return [Flt::DecNum] the required monthly payment.  For loans with more than one rate, returns nil
     attr_reader :payment
     # @return [Flt::DecNum] the principal amount of the loan
@@ -103,7 +110,7 @@ module Finrb
     # @param [Flt::DecNum] principal the initial amount of the loan or investment
     # @param [Rate] rates the applicable interest rates
     # @param [Proc] block
-    def initialize(principal, *rates, balloon: 0, &block)
+    def initialize(principal, *rates, balloon: 0, interest_only_periods: 0, &block)
       @principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless @principal.positive?
 
@@ -118,7 +125,11 @@ module Finrb
 
       # compute the total duration from all of the rates.
       @periods = rates.sum(&:duration)
-      @period  = 0
+      valid_interest_only = interest_only_periods.is_a?(Integer) && interest_only_periods.between?(0, @periods - 1)
+      raise(ArgumentError, 'interest_only_periods must be a non-negative integer shorter than the loan term.') unless valid_interest_only
+
+      @interest_only_periods = interest_only_periods
+      @period = 0
 
       compute
     end
@@ -127,7 +138,7 @@ module Finrb
     # @return [Numeric] -1, 0, or +1
     # @param [Amortization] other
     def ==(other)
-      (principal == other.principal) && (balloon == other.balloon) && (rates == other.rates) && (payments == other.payments)
+      (principal == other.principal) && (balloon == other.balloon) && (interest_only_periods == other.interest_only_periods) && (rates == other.rates) && (payments == other.payments)
     end
 
     # @return [Array] the amount of any additional payments in each period
@@ -143,19 +154,14 @@ module Finrb
     # @return none
     # @param [Rate] rate the interest rate to use in the amortization
     def amortize(rate)
-      # For the purposes of calculating a payment, the relevant time
-      # period is the remaining number of periods in the loan, not
-      # necessarily the duration of the rate itself.
-      periods = @periods - @period
-      amount = Amortization.payment(@balance, rate.monthly, periods, balloon: @balloon)
-
-      pmt = Payment.new(amount, period: @period)
-      pmt.modify(&@block) if @block
-      raise(ArgumentError, 'payment modification must produce a negative amount.') unless pmt.amount.negative?
+      regular_payment = nil
 
       rate.duration.to_i.times do
         # Do this first in case the balance is zero already.
         break if @balance.zero?
+
+        interest_only = @period < @interest_only_periods
+        regular_payment ||= build_regular_payment(rate) unless interest_only
 
         # Compute and record interest on the outstanding balance.
         int = Precision.money(@balance * rate.monthly)
@@ -163,11 +169,13 @@ module Finrb
         @balance += interest.amount
         @transactions << interest.dup
 
-        # Record payment.  Don't pay more than the outstanding balance.
-        pmt.amount = -@balance if pmt.amount.abs > @balance
-        @additional_by_period << [-pmt.difference, Flt::DecNum(0)].max
-        @transactions << pmt.dup
-        @balance += pmt.amount
+        payment = interest_only ? build_interest_only_payment(int) : regular_payment
+        payment.period = @period
+        payment.amount = -@balance if payment.amount.abs > @balance
+        @additional_by_period << [-payment.difference, Flt::DecNum(0)].max
+        @interest_only_by_period << interest_only
+        @transactions << payment.dup
+        @balance += payment.amount
 
         @period += 1
       end
@@ -179,6 +187,7 @@ module Finrb
       @balance = @principal
       @transactions = []
       @additional_by_period = []
+      @interest_only_by_period = []
 
       @rates.each do |rate|
         amortize(rate)
@@ -192,11 +201,12 @@ module Finrb
         @balance = 0
       end
 
-      @payment = (payments.first if @rates.length == 1)
+      @payment = (payments.first if @rates.length == 1 && @interest_only_periods.zero?)
 
       @transactions.freeze
       @additional_by_period.freeze
       @balloon_by_period.freeze
+      @interest_only_by_period.freeze
       @schedule = build_schedule.freeze
     end
 
@@ -248,10 +258,34 @@ module Finrb
       @transactions.each_slice(2).with_index.map do |(interest, payment), index|
         principal = -(payment.amount + interest.amount)
         closing_balance = opening_balance - principal
-        entry = Entry.new(period: payment.period, opening_balance:, payment: payment.amount, interest: interest.amount, principal:, additional_payment: @additional_by_period.fetch(index), balloon_payment: @balloon_by_period.fetch(index), closing_balance:)
+        entry = Entry.new(period: payment.period, opening_balance:, payment: payment.amount, interest: interest.amount, principal:, additional_payment: @additional_by_period.fetch(index), balloon_payment: @balloon_by_period.fetch(index), interest_only: @interest_only_by_period.fetch(index), closing_balance:)
         opening_balance = closing_balance
         entry
       end
+    end
+
+    def build_regular_payment(rate)
+      periods = @periods - @period
+      amount = Amortization.payment(@balance, rate.monthly, periods, balloon: @balloon)
+      Payment.new(amount, period: @period).tap do |payment|
+        payment.modify(&@block) if @block
+        validate_payment!(payment)
+      end
+    end
+
+    def build_interest_only_payment(interest)
+      Payment.new(-interest, period: @period).tap do |payment|
+        payment.modify(&@block) if @block
+        validate_payment!(payment, allow_zero: true)
+      end
+    end
+
+    def validate_payment!(payment, allow_zero: false)
+      valid = payment.amount.negative? || (allow_zero && payment.amount.zero?)
+      return if valid
+
+      requirement = allow_zero ? 'must not produce a positive amount' : 'must produce a negative amount'
+      raise(ArgumentError, "payment modification #{requirement}.")
     end
   end
 end

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -63,6 +63,12 @@ module Finrb
     attr_reader :balance
     # @return [Flt::DecNum] contractual principal settled as a balloon in the final period
     attr_reader :balloon
+    # @return [Flt::DecNum] principal balance including any financed origination fee
+    attr_reader :amount_financed
+    # @return [Flt::DecNum] cash made available to the borrower after an unfinanced fee
+    attr_reader :net_proceeds
+    # @return [Flt::DecNum] fee charged when the loan is originated
+    attr_reader :origination_fee
     # @return [Integer] number of leading periods that pay interest but no scheduled principal
     attr_reader :interest_only_periods
     # @return [Flt::DecNum] the required monthly payment.  For loans with more than one rate, returns nil
@@ -110,12 +116,21 @@ module Finrb
     # @param [Flt::DecNum] principal the initial amount of the loan or investment
     # @param [Rate] rates the applicable interest rates
     # @param [Proc] block
-    def initialize(principal, *rates, balloon: 0, interest_only_periods: 0, &block)
+    def initialize(principal, *rates, balloon: 0, interest_only_periods: 0, origination_fee: 0, finance_origination_fee: false, &block)
       @principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless @principal.positive?
 
+      @origination_fee = Validation.decimal(origination_fee, name: 'origination_fee')
+      raise(ArgumentError, 'origination_fee must be non-negative.') if @origination_fee.negative?
+      raise(ArgumentError, 'finance_origination_fee must be true or false.') unless [true, false].include?(finance_origination_fee)
+      raise(ArgumentError, 'an unfinanced origination_fee must be less than principal.') if !finance_origination_fee && @origination_fee >= @principal
+
+      @finance_origination_fee = finance_origination_fee
+      @amount_financed = @principal + (finance_origination_fee ? @origination_fee : 0)
+      @net_proceeds = @principal - (finance_origination_fee ? 0 : @origination_fee)
+
       @balloon = Validation.decimal(balloon, name: 'balloon')
-      raise(ArgumentError, 'balloon must be non-negative and less than principal.') if @balloon.negative? || @balloon >= @principal
+      raise(ArgumentError, 'balloon must be non-negative and less than amount financed.') if @balloon.negative? || @balloon >= @amount_financed
       raise(ArgumentError, 'at least one rate is required.') if rates.empty?
       raise(ArgumentError, 'rates must be Finrb::Rate instances.') unless rates.all?(Rate)
       raise(ArgumentError, 'every rate must have a duration.') if rates.any? { |rate| rate.duration.nil? }
@@ -138,8 +153,11 @@ module Finrb
     # @return [Numeric] -1, 0, or +1
     # @param [Amortization] other
     def ==(other)
-      (principal == other.principal) && (balloon == other.balloon) && (interest_only_periods == other.interest_only_periods) && (rates == other.rates) && (payments == other.payments)
+      (principal == other.principal) && (origination_fee == other.origination_fee) && (finance_origination_fee? == other.finance_origination_fee?) && (balloon == other.balloon) && (interest_only_periods == other.interest_only_periods) && (rates == other.rates) && (payments == other.payments)
     end
+
+    attr_reader :finance_origination_fee
+    alias finance_origination_fee? finance_origination_fee
 
     # @return [Array] the amount of any additional payments in each period
     # @example
@@ -184,7 +202,7 @@ module Finrb
     # compute the amortization of the principal
     # @return none
     def compute
-      @balance = @principal
+      @balance = @amount_financed
       @transactions = []
       @additional_by_period = []
       @interest_only_by_period = []
@@ -254,7 +272,7 @@ module Finrb
     private
 
     def build_schedule
-      opening_balance = @principal
+      opening_balance = @amount_financed
       @transactions.each_slice(2).with_index.map do |(interest, payment), index|
         principal = -(payment.amount + interest.amount)
         closing_balance = opening_balance - principal

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -18,7 +18,6 @@ module Finrb
   # @example Borrow $250,000 under a 30 year, fixed-rate loan with a 4.25% APR, but pay $150 extra each month
   #   rate = Rate.new(0.0425, :apr, :duration => (5 * 12))
   #   extra_payments = Finrb::Amortization.new(250000, rate){ |period| period.payment - 150 }
-  # @api public
   class Amortization
     # Immutable breakdown of one amortization period. Payments retain finrb's
     # cashflow sign convention and are negative; the other monetary fields are
@@ -56,22 +55,16 @@ module Finrb
     end
 
     # @return [Flt::DecNum] the balance of the loan at the end of the amortization period (usually zero)
-    # @api public
     attr_reader :balance
     # @return [Flt::DecNum] contractual principal settled as a balloon in the final period
-    # @api public
     attr_reader :balloon
     # @return [Flt::DecNum] the required monthly payment.  For loans with more than one rate, returns nil
-    # @api public
     attr_reader :payment
     # @return [Flt::DecNum] the principal amount of the loan
-    # @api public
     attr_reader :principal
     # @return [Array] the interest rates used for calculating the amortization
-    # @api public
     attr_reader :rates
     # @return [Array<Entry>] immutable period-by-period loan breakdown
-    # @api public
     attr_reader :schedule
 
     # @return [Flt::DecNum] the periodic payment due on a loan
@@ -84,7 +77,6 @@ module Finrb
     #   rate.duration #=> 360
     #   Amortization.payment(200000, rate.monthly, rate.duration) #=> Flt::DecNum('-926.23')
     # @see https://en.wikipedia.org/wiki/Amortization_calculator
-    # @api public
     def self.payment(principal, rate, periods, balloon: 0)
       principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless principal.positive?
@@ -111,7 +103,6 @@ module Finrb
     # @param [Flt::DecNum] principal the initial amount of the loan or investment
     # @param [Rate] rates the applicable interest rates
     # @param [Proc] block
-    # @api public
     def initialize(principal, *rates, balloon: 0, &block)
       @principal = Validation.decimal(principal, name: 'principal')
       raise(ArgumentError, 'principal must be positive.') unless @principal.positive?
@@ -135,7 +126,6 @@ module Finrb
     # compare two Amortization instances
     # @return [Numeric] -1, 0, or +1
     # @param [Amortization] other
-    # @api public
     def ==(other)
       (principal == other.principal) && (balloon == other.balloon) && (rates == other.rates) && (payments == other.payments)
     end
@@ -145,7 +135,6 @@ module Finrb
     #   rate = Rate.new(0.0375, :apr, :duration => (30 * 12))
     #   amt = Finrb::Amortization.new(300000, rate){ |payment| payment.amount-100}
     #   amt.additional_payments #=> [Flt::DecNum('-100.00'), Flt::DecNum('-100.00'), ... ]
-    # @api public
     def additional_payments
       @transactions.filter_map { |trans| trans.difference if trans.payment? }
     end
@@ -153,7 +142,6 @@ module Finrb
     # amortize the balance of loan with the given interest rate
     # @return none
     # @param [Rate] rate the interest rate to use in the amortization
-    # @api private
     def amortize(rate)
       # For the purposes of calculating a payment, the relevant time
       # period is the remaining number of periods in the loan, not
@@ -187,7 +175,6 @@ module Finrb
 
     # compute the amortization of the principal
     # @return none
-    # @api private
     def compute
       @balance = @principal
       @transactions = []
@@ -213,6 +200,8 @@ module Finrb
       @schedule = build_schedule.freeze
     end
 
+    private :amortize, :compute
+
     # @return [Integer] the time required to pay off the loan, in months
     # @example In most cases, the duration is equal to the total duration of all rates
     #   rate = Rate.new(0.0375, :apr, :duration => (30 * 12))
@@ -222,12 +211,10 @@ module Finrb
     #   rate = Rate.new(0.0375, :apr, :duration => (30 * 12))
     #   amt = Finrb::Amortization.new(300000, rate){ |payment| payment.amount-100}
     #   amt.duration #=> 319
-    # @api public
     def duration
       payments.length
     end
 
-    # @api public
     def inspect
       "Amortization.new(#{@principal})"
     end
@@ -241,7 +228,6 @@ module Finrb
     #   rate = Rate.new(0.0375, :apr, :duration => (30 * 12))
     #   amt = Finrb::Amortization.new(300000, rate)
     #   amt.interest[0,6].sum #=> Flt::DecNum('5603.74')
-    # @api public
     def interest
       @transactions.filter_map { |trans| trans.amount if trans.interest? }
     end
@@ -251,7 +237,6 @@ module Finrb
     #   rate = Rate.new(0.0375, :apr, :duration => (30 * 12))
     #   amt = Finrb::Amortization.new(300000, rate)
     #   amt.payments.sum #=> Flt::DecNum('-500163.94')
-    # @api public
     def payments
       @transactions.filter_map { |trans| trans.amount if trans.payment? }
     end

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -20,6 +20,41 @@ module Finrb
   #   extra_payments = Finrb::Amortization.new(250000, rate){ |period| period.payment - 150 }
   # @api public
   class Amortization
+    # Immutable breakdown of one amortization period. Payments retain finrb's
+    # cashflow sign convention and are negative; the other monetary fields are
+    # non-negative.
+    class Entry
+      ATTRIBUTES = %i[period opening_balance payment interest principal additional_payment closing_balance].freeze
+      private_constant :ATTRIBUTES
+
+      attr_reader(*ATTRIBUTES)
+
+      def initialize(period:, opening_balance:, payment:, interest:, principal:, additional_payment:, closing_balance:)
+        raise(ArgumentError, 'period must be a non-negative integer.') unless period.is_a?(Integer) && !period.negative?
+
+        @period = period
+        ATTRIBUTES.drop(1).each do |name|
+          value = binding.local_variable_get(name)
+          instance_variable_set("@#{name}", Validation.decimal(value, name: name.to_s))
+        end
+        freeze
+      end
+
+      def ==(other)
+        other.instance_of?(self.class) && ATTRIBUTES.all? { |name| public_send(name) == other.public_send(name) }
+      end
+      alias eql? ==
+
+      def hash
+        attributes = ATTRIBUTES.map { |name| public_send(name) }
+        attributes.hash
+      end
+
+      def to_h
+        ATTRIBUTES.to_h { |name| [name, public_send(name)] }
+      end
+    end
+
     # @return [Flt::DecNum] the balance of the loan at the end of the amortization period (usually zero)
     # @api public
     attr_reader :balance
@@ -32,6 +67,9 @@ module Finrb
     # @return [Array] the interest rates used for calculating the amortization
     # @api public
     attr_reader :rates
+    # @return [Array<Entry>] immutable period-by-period loan breakdown
+    # @api public
+    attr_reader :schedule
 
     # @return [Flt::DecNum] the periodic payment due on a loan
     # @param [Flt::DecNum] principal the initial amount of the loan or investment
@@ -129,6 +167,7 @@ module Finrb
 
         # Record payment.  Don't pay more than the outstanding balance.
         pmt.amount = -@balance if pmt.amount.abs > @balance
+        @additional_by_period << [-pmt.difference, Flt::DecNum(0)].max
         @transactions << pmt.dup
         @balance += pmt.amount
 
@@ -142,6 +181,7 @@ module Finrb
     def compute
       @balance = @principal
       @transactions = []
+      @additional_by_period = []
 
       @rates.each do |rate|
         amortize(rate)
@@ -156,6 +196,8 @@ module Finrb
       @payment = (payments.first if @rates.length == 1)
 
       @transactions.freeze
+      @additional_by_period.freeze
+      @schedule = build_schedule.freeze
     end
 
     # @return [Integer] the time required to pay off the loan, in months
@@ -199,6 +241,19 @@ module Finrb
     # @api public
     def payments
       @transactions.filter_map { |trans| trans.amount if trans.payment? }
+    end
+
+    private
+
+    def build_schedule
+      opening_balance = @principal
+      @transactions.each_slice(2).with_index.map do |(interest, payment), index|
+        principal = -(payment.amount + interest.amount)
+        closing_balance = opening_balance - principal
+        entry = Entry.new(period: payment.period, opening_balance:, payment: payment.amount, interest: interest.amount, principal:, additional_payment: @additional_by_period.fetch(index), closing_balance:)
+        opening_balance = closing_balance
+        entry
+      end
     end
   end
 end

--- a/lib/finrb/cashflows.rb
+++ b/lib/finrb/cashflows.rb
@@ -23,6 +23,10 @@ module Finrb
         sequence(cashflows).npv(rate)
       end
 
+      def mirr(cashflows, finance_rate:, reinvestment_rate:)
+        sequence(cashflows).mirr(finance_rate:, reinvestment_rate:)
+      end
+
       def xirr(transactions, guess = nil)
         sequence(transactions).xirr(guess)
       end
@@ -85,6 +89,33 @@ module Finrb
       end
 
       total
+    end
+
+    # Calculate the modified internal rate of return for equally spaced
+    # cashflows using separate financing and reinvestment assumptions.
+    # @return [Flt::DecNum] modified per-period internal rate of return
+    def mirr(finance_rate:, reinvestment_rate:)
+      validate_numeric_cashflows!
+      raise(InvalidCashflowError, 'MIRR requires at least two cashflows.') if size < 2
+
+      cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
+      raise(InvalidCashflowError, 'Cashflow needs at least one positive and one negative value.') if cashflows.none?(&:positive?) || cashflows.none?(&:negative?)
+
+      finance_rate = Validation.decimal(finance_rate, name: 'finance_rate')
+      reinvestment_rate = Validation.decimal(reinvestment_rate, name: 'reinvestment_rate')
+      raise(DomainError, 'Finance and reinvestment rates must be greater than -1.') if finance_rate <= -1 || reinvestment_rate <= -1
+
+      last_period = cashflows.size - 1
+      future_positive =
+        cashflows.each_with_index.sum do |amount, index|
+          amount.positive? ? amount * ((reinvestment_rate + 1)**(last_period - index)) : Flt::DecNum(0)
+        end
+      present_negative =
+        cashflows.each_with_index.sum do |amount, index|
+          amount.negative? ? amount / ((finance_rate + 1)**index) : Flt::DecNum(0)
+        end
+
+      ((future_positive / -present_negative)**(Flt::DecNum(1) / last_period)) - 1
     end
 
     # Calculate the effective annual internal rate of return for an ordered

--- a/lib/finrb/cashflows.rb
+++ b/lib/finrb/cashflows.rb
@@ -12,7 +12,6 @@ require 'date'
 
 module Finrb
   # Provides methods for working with cash flows (collections of transactions)
-  # @api public
   module Cashflow
     class << self
       def irr(cashflows, guess = nil)
@@ -59,7 +58,6 @@ module Finrb
     # @example
     #   Finrb::Cashflow.irr([-4000,1200,1410,1875,1050]) #=> 0.143
     # @see https://en.wikipedia.org/wiki/Internal_rate_of_return
-    # @api public
     def irr(guess = nil)
       validate_numeric_cashflows!
 
@@ -75,7 +73,6 @@ module Finrb
     # @example
     #   Finrb::Cashflow.npv([-100.0, 60, 60, 60], 0.1) #=> 49.211
     # @see https://en.wikipedia.org/wiki/Net_present_value
-    # @api public
     def npv(rate)
       validate_numeric_cashflows!
       cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
@@ -139,7 +136,6 @@ module Finrb
     #   @transactions << Transaction.new(  600, :date => Time.new(1990,01,01))
     #   @transactions << Transaction.new(  600, :date => Time.new(1995,01,01))
     #   Finrb::Cashflow.xirr(@transactions, 0.6) #=> Rate("0.024851", :effective, :compounds => :annually)
-    # @api public
     def xirr(guess = nil)
       validate_dated_cashflows!
 
@@ -158,7 +154,6 @@ module Finrb
     #   @transactions << Transaction.new(  600, :date => Time.new(1990,01,01))
     #   @transactions << Transaction.new(  600, :date => Time.new(1995,01,01))
     #   Finrb::Cashflow.xnpv(@transactions, 0.6).round(2) #=> -937.41
-    # @api public
     def xnpv(rate)
       validate_dated_cashflows!
       rate = Validation.decimal(rate, name: 'rate')

--- a/lib/finrb/rates.rb
+++ b/lib/finrb/rates.rb
@@ -6,7 +6,6 @@ require_relative 'validation'
 module Finrb
   # the Rate class provides an interface for working with interest rates.
   # {render:Rate#new}
-  # @api public
   class Rate
     include Comparable
 
@@ -31,7 +30,6 @@ module Finrb
     # @param [Numeric] periods the number of compounding periods per year
     # @example
     #   Rate.to_effective(0.05, 4) #=> Flt::DecNum('0.05095')
-    # @api public
     def self.to_effective(rate, periods)
       rate = Validation.decimal(rate, name: 'rate')
       periods = compounding_periods(periods)
@@ -50,7 +48,6 @@ module Finrb
     # @example
     #   Rate.to_nominal(0.06, 365) #=> Flt::DecNum('0.05827')
     # @see https://www.miniwebtool.com/nominal-interest-rate-calculator/
-    # @api public
     def self.to_nominal(rate, periods)
       rate = Validation.decimal(rate, name: 'rate')
       raise(ArgumentError, 'effective rate must be greater than -1.') if rate <= -1
@@ -75,7 +72,6 @@ module Finrb
     #   Rate.new(0.035, :apr) #=> Rate(0.035, :apr)
     # @see https://en.wikipedia.org/wiki/Effective_interest_rate
     # @see https://en.wikipedia.org/wiki/Nominal_interest_rate
-    # @api public
     def initialize(rate, type, opts = {})
       raise(ArgumentError, 'options must be a Hash.') unless opts.is_a?(Hash)
       raise(ArgumentError, 'options may only contain compounds and duration.') unless (opts.keys - %i[compounds duration]).empty?
@@ -97,13 +93,10 @@ module Finrb
     end
 
     # @return [Integer] the duration for which the rate is valid, in months
-    # @api public
     attr_reader :duration
     # @return [Flt::DecNum] the effective interest rate
-    # @api public
     attr_reader :effective
     # @return [Flt::DecNum] the nominal interest rate
-    # @api public
     attr_reader :nominal
 
     # compare two Rates, using the effective rate
@@ -113,21 +106,18 @@ module Finrb
     #   r1 = Rate.new(0.15, :nominal) #=> Rate.new(0.160755, :apr)
     #   r2 = Rate.new(0.155, :nominal, :compounds => :semiannually) #=> Rate.new(0.161006, :apr)
     #   r1 <=> r2 #=> -1
-    # @api public
     def <=>(other)
       @effective <=> other.effective
     end
 
     # Return the nominal annual percentage rate for the configured compounding frequency.
     # @return [Flt::DecNum] the nominal annual percentage rate
-    # @api public
     def apr
       nominal
     end
 
     # Return the effective annual percentage yield.
     # @return [Flt::DecNum] the effective annual percentage yield
-    # @api public
     def apy
       effective
     end
@@ -136,7 +126,6 @@ module Finrb
     # @return none
     # @param [Symbol, Numeric] input the compounding frequency
     # @raise [ArgumentError] if input is not an accepted keyword or Numeric
-    # @api private
     def compounds=(input)
       @periods =
         case input
@@ -158,7 +147,6 @@ module Finrb
     # set the effective interest rate
     # @return none
     # @param [Flt::DecNum] rate the effective interest rate
-    # @api private
     def effective=(rate)
       raise(ArgumentError, 'effective rate must be greater than -1.') if rate <= -1
 
@@ -176,7 +164,6 @@ module Finrb
     #   rate.apr.round(6) #=> Flt::DecNum('0.15')
     #   rate.apy.round(6) #=> Flt::DecNum('0.160755')
     #   rate.monthly.round(6) #=> Flt::DecNum('0.0125')
-    # @api public
     def monthly
       @monthly ||= Precision.rate(Rate.to_nominal(effective, 12) / 12)
     end
@@ -184,7 +171,6 @@ module Finrb
     # set the nominal interest rate
     # @return none
     # @param [Flt::DecNum] rate the nominal interest rate
-    # @api private
     def nominal=(rate)
       raise(ArgumentError, 'nominal rate must keep every compounded period greater than -100%.') if !@periods.infinite? && rate <= -@periods
 

--- a/lib/finrb/returns.rb
+++ b/lib/finrb/returns.rb
@@ -2,6 +2,7 @@
 
 require_relative 'decimal'
 require_relative 'errors'
+require_relative 'validation'
 
 module Finrb
   # Investment return and risk-adjusted performance calculations.
@@ -16,6 +17,27 @@ module Finrb
       end
     end
     private_class_method :wrap_array
+
+    # Compound annual growth rate over a positive number of periods.
+    #
+    # Beginning value must be positive. Ending value may be zero, representing
+    # a total loss, but cannot be negative because a fractional growth root
+    # would not have a generally meaningful real-valued result.
+    #
+    # @param beginning_value [Numeric] value at the start of the measurement
+    # @param ending_value [Numeric] value at the end of the measurement
+    # @param periods [Integer] number of equal annual periods
+    # @return [Flt::DecNum] compound growth rate per period
+    def self.cagr(beginning_value:, ending_value:, periods:)
+      beginning_value = Validation.decimal(beginning_value, name: 'beginning_value')
+      ending_value = Validation.decimal(ending_value, name: 'ending_value')
+      periods = Validation.positive_integer(periods, name: 'periods')
+
+      raise(ArgumentError, 'beginning_value must be greater than zero.') unless beginning_value.positive?
+      raise(ArgumentError, 'ending_value must be greater than or equal to zero.') if ending_value.negative?
+
+      ((ending_value / beginning_value)**(Flt::DecNum(1) / periods)) - 1
+    end
 
     # Computing Coefficient of variation
     #

--- a/lib/finrb/returns.rb
+++ b/lib/finrb/returns.rb
@@ -39,6 +39,86 @@ module Finrb
       ((ending_value / beginning_value)**(Flt::DecNum(1) / periods)) - 1
     end
 
+    def self.risk_values(values, name:)
+      values = wrap_array(values)
+      raise(ArgumentError, "#{name} cannot be empty.") if values.empty?
+
+      values.map { |value| Validation.decimal(value, name:) }
+    end
+    private_class_method :risk_values
+
+    # Compound a periodic return into an annual return.
+    def self.annualize_return(rate:, periods_per_year:)
+      rate = Validation.decimal(rate, name: 'rate')
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      raise(ArgumentError, 'rate must be greater than or equal to -1.') if rate < -1
+
+      ((rate + 1)**periods_per_year) - 1
+    end
+
+    # Scale periodic volatility by the square root of periods per year.
+    def self.annualize_volatility(volatility:, periods_per_year:)
+      volatility = Validation.decimal(volatility, name: 'volatility')
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      raise(ArgumentError, 'volatility must be greater than or equal to zero.') if volatility.negative?
+
+      volatility * (Flt::DecNum(periods_per_year)**Flt::DecNum('0.5'))
+    end
+
+    # Standard deviation of periodic returns. Sample volatility uses n - 1;
+    # population volatility uses n.
+    def self.volatility(returns:, sample: true)
+      raise(ArgumentError, 'sample must be true or false.') unless [true, false].include?(sample)
+
+      returns = risk_values(returns, name: 'return')
+      raise(ArgumentError, 'sample volatility requires at least two returns.') if sample && returns.size < 2
+
+      mean = returns.sum / returns.size
+      denominator = sample ? returns.size - 1 : returns.size
+      variance = returns.sum { |value| (value - mean)**2 } / denominator
+      variance**Flt::DecNum('0.5')
+    end
+
+    # Root-mean-square return shortfall below a target return. The denominator
+    # includes every observation, including returns at or above the target.
+    def self.downside_deviation(returns:, target: 0)
+      returns = risk_values(returns, name: 'return')
+      target = Validation.decimal(target, name: 'target')
+      squared_shortfalls =
+        returns.sum do |value|
+          shortfall = [value - target, Flt::DecNum(0)].min
+          shortfall**2
+        end
+
+      (squared_shortfalls / returns.size)**Flt::DecNum('0.5')
+    end
+
+    # Sortino ratio using arithmetic mean excess return and downside deviation.
+    def self.sortino_ratio(returns:, target: 0, periods_per_year: nil)
+      returns = risk_values(returns, name: 'return')
+      target = Validation.decimal(target, name: 'target')
+      downside = downside_deviation(returns:, target:)
+      raise(ArgumentError, 'downside deviation must be greater than zero.') if downside.zero?
+
+      ratio = ((returns.sum / returns.size) - target) / downside
+      return ratio if periods_per_year.nil?
+
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      ratio * (Flt::DecNum(periods_per_year)**Flt::DecNum('0.5'))
+    end
+
+    # Largest peak-to-trough decline as a non-negative fraction.
+    def self.max_drawdown(values:)
+      values = risk_values(values, name: 'value')
+      raise(ArgumentError, 'values must be greater than zero.') unless values.all?(&:positive?)
+
+      peak = values.first
+      values.reduce(Flt::DecNum(0)) do |maximum, value|
+        peak = value if value > peak
+        [maximum, (peak - value) / peak].max
+      end
+    end
+
     # Computing Coefficient of variation
     #
     # @param sd standard deviation

--- a/lib/finrb/transaction.rb
+++ b/lib/finrb/transaction.rb
@@ -4,17 +4,13 @@ require_relative 'validation'
 
 module Finrb
   # the Transaction class provides a general interface for working with individual cash flows.
-  # @api public
   class Transaction
     # @return [Flt::DecNum] the cash value of the transaction
-    # @api public
     attr_reader :amount
     # @return [Integer] the period number of the transaction
     # @note this attribute is mainly used in the case of mortgage amortization with no dates
-    # @api public
     attr_reader :period
     # @return [Date] the date of the transaction
-    # @api public
     attr_reader :date
 
     # create a new Transaction
@@ -26,7 +22,6 @@ module Finrb
     #   t = Transaction.new(400)
     # @example a transaction with a period number
     #   t = Transaction.new(400, :period => 3)
-    # @api public
     def initialize(amount, opts = {})
       raise(ArgumentError, 'options must be a Hash.') unless opts.is_a?(Hash)
       raise(ArgumentError, 'options may only contain date and period.') unless (opts.keys - %i[date period]).empty?
@@ -47,7 +42,6 @@ module Finrb
     #   t = Transaction.new(500)
     #   t.amount = 750
     #   t.amount #=> 750
-    # @api public
     def amount=(value)
       @amount = Validation.decimal(value, name: 'amount')
     end
@@ -71,7 +65,6 @@ module Finrb
     #   t = Transaction.new(500)
     #   t.amount = 750
     #   t.difference #=> Flt::DecNum('250')
-    # @api public
     def difference
       @amount - @original
     end
@@ -82,12 +75,10 @@ module Finrb
     #   int = Interest.new(500)
     #   pmt.interest? #=> False
     #   int.interest? #=> True
-    # @api public
     def interest?
       instance_of?(Interest)
     end
 
-    # @api public
     def inspect
       "Transaction(#{@amount.round(2)}, date: #{@date})"
     end
@@ -99,7 +90,6 @@ module Finrb
     #   pmt = Payment.new(-500)
     #   pmt.modify { |t| t.amount-100 }
     #   pmt.amount #=> -600
-    # @api public
     def modify
       self.amount = yield(self)
     end
@@ -116,7 +106,6 @@ module Finrb
     #   int = Interest.new(500)
     #   pmt.payment? #=> True
     #   int.payment? #=> False
-    # @api public
     def payment?
       instance_of?(Payment)
     end

--- a/lib/finrb/version.rb
+++ b/lib/finrb/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Finrb
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
   public_constant :VERSION
 end

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -94,6 +94,21 @@ module Finrb
   end
 
   class Amortization
+    class Entry
+      def initialize: (period: Integer, opening_balance: number, payment: number, interest: number, principal: number, additional_payment: number, closing_balance: number) -> void
+      def period: () -> Integer
+      def opening_balance: () -> decimal
+      def payment: () -> decimal
+      def interest: () -> decimal
+      def principal: () -> decimal
+      def additional_payment: () -> decimal
+      def closing_balance: () -> decimal
+      def ==: (untyped) -> bool
+      def eql?: (untyped) -> bool
+      def hash: () -> Integer
+      def to_h: () -> Hash[Symbol, Integer | decimal]
+    end
+
     def self.payment: (number, number, Integer) -> decimal
 
     def initialize: (number, *Rate) ?{ (Transaction) -> number } -> void
@@ -102,6 +117,7 @@ module Finrb
     def payment: () -> decimal?
     def principal: () -> decimal
     def rates: () -> Array[Rate]
+    def schedule: () -> Array[Entry]
     def additional_payments: () -> Array[decimal]
     def duration: () -> Integer
     def inspect: () -> String

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -114,10 +114,15 @@ module Finrb
 
     def self.payment: (number, number, Integer, ?balloon: number) -> decimal
 
-    def initialize: (number, *Rate, ?balloon: number, ?interest_only_periods: Integer) ?{ (Transaction) -> number } -> void
+    def initialize: (number, *Rate, ?balloon: number, ?interest_only_periods: Integer, ?origination_fee: number, ?finance_origination_fee: bool) ?{ (Transaction) -> number } -> void
     def ==: (untyped) -> bool
     def balance: () -> decimal
     def balloon: () -> decimal
+    def amount_financed: () -> decimal
+    def net_proceeds: () -> decimal
+    def origination_fee: () -> decimal
+    def finance_origination_fee: () -> bool
+    def finance_origination_fee?: () -> bool
     def interest_only_periods: () -> Integer
     def payment: () -> decimal?
     def principal: () -> decimal

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -95,7 +95,7 @@ module Finrb
 
   class Amortization
     class Entry
-      def initialize: (period: Integer, opening_balance: number, payment: number, interest: number, principal: number, additional_payment: number, balloon_payment: number, closing_balance: number) -> void
+      def initialize: (period: Integer, opening_balance: number, payment: number, interest: number, principal: number, additional_payment: number, balloon_payment: number, interest_only: bool, closing_balance: number) -> void
       def period: () -> Integer
       def opening_balance: () -> decimal
       def payment: () -> decimal
@@ -103,6 +103,8 @@ module Finrb
       def principal: () -> decimal
       def additional_payment: () -> decimal
       def balloon_payment: () -> decimal
+      def interest_only: () -> bool
+      def interest_only?: () -> bool
       def closing_balance: () -> decimal
       def ==: (untyped) -> bool
       def eql?: (untyped) -> bool
@@ -112,10 +114,11 @@ module Finrb
 
     def self.payment: (number, number, Integer, ?balloon: number) -> decimal
 
-    def initialize: (number, *Rate, ?balloon: number) ?{ (Transaction) -> number } -> void
+    def initialize: (number, *Rate, ?balloon: number, ?interest_only_periods: Integer) ?{ (Transaction) -> number } -> void
     def ==: (untyped) -> bool
     def balance: () -> decimal
     def balloon: () -> decimal
+    def interest_only_periods: () -> Integer
     def payment: () -> decimal?
     def principal: () -> decimal
     def rates: () -> Array[Rate]

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -111,11 +111,13 @@ module Finrb
 
   module Cashflow
     def self.irr: (Enumerable[number], ?number) -> decimal
+    def self.mirr: (Enumerable[number], finance_rate: number, reinvestment_rate: number) -> decimal
     def self.npv: (Enumerable[number], number) -> decimal
     def self.xirr: (Enumerable[Transaction], ?number) -> Rate
     def self.xnpv: (Enumerable[Transaction], number) -> decimal
 
     def irr: (?number) -> decimal
+    def mirr: (finance_rate: number, reinvestment_rate: number) -> decimal
     def npv: (number) -> decimal
     def xirr: (?number) -> Rate
     def xnpv: (number) -> decimal
@@ -163,16 +165,22 @@ module Finrb
   end
 
   module Returns
+    def self.annualize_return: (rate: number, periods_per_year: Integer) -> decimal
+    def self.annualize_volatility: (volatility: number, periods_per_year: Integer) -> decimal
     def self.cagr: (beginning_value: number, ending_value: number, periods: Integer) -> decimal
     def self.coefficient_variation: (sd: number, avg: number) -> decimal
     def self.geometric_mean: (r: number | numbers) -> decimal
     def self.harmonic_mean: (p: number | numbers) -> decimal
     def self.hpr: (ev: number, bv: number, ?cfr: number) -> decimal
+    def self.downside_deviation: (returns: number | numbers, ?target: number) -> decimal
+    def self.max_drawdown: (values: number | numbers) -> decimal
     def self.sampling_error: (sm: number, mu: number) -> decimal
     def self.sf_ratio: (rp: number, rl: number, sd: number) -> decimal
     def self.sharpe_ratio: (rp: number, rf: number, sd: number) -> decimal
+    def self.sortino_ratio: (returns: number | numbers, ?target: number, ?periods_per_year: Integer?) -> decimal
     def self.twrr: (ev: number | numbers, bv: number | numbers, cfr: number | numbers) -> decimal
     def self.wpr: (r: number | numbers, w: number | numbers) -> decimal
+    def self.volatility: (returns: number | numbers, ?sample: bool) -> decimal
   end
 
   module Yields

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -163,6 +163,7 @@ module Finrb
   end
 
   module Returns
+    def self.cagr: (beginning_value: number, ending_value: number, periods: Integer) -> decimal
     def self.coefficient_variation: (sd: number, avg: number) -> decimal
     def self.geometric_mean: (r: number | numbers) -> decimal
     def self.harmonic_mean: (p: number | numbers) -> decimal

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -95,13 +95,14 @@ module Finrb
 
   class Amortization
     class Entry
-      def initialize: (period: Integer, opening_balance: number, payment: number, interest: number, principal: number, additional_payment: number, closing_balance: number) -> void
+      def initialize: (period: Integer, opening_balance: number, payment: number, interest: number, principal: number, additional_payment: number, balloon_payment: number, closing_balance: number) -> void
       def period: () -> Integer
       def opening_balance: () -> decimal
       def payment: () -> decimal
       def interest: () -> decimal
       def principal: () -> decimal
       def additional_payment: () -> decimal
+      def balloon_payment: () -> decimal
       def closing_balance: () -> decimal
       def ==: (untyped) -> bool
       def eql?: (untyped) -> bool
@@ -109,11 +110,12 @@ module Finrb
       def to_h: () -> Hash[Symbol, Integer | decimal]
     end
 
-    def self.payment: (number, number, Integer) -> decimal
+    def self.payment: (number, number, Integer, ?balloon: number) -> decimal
 
-    def initialize: (number, *Rate) ?{ (Transaction) -> number } -> void
+    def initialize: (number, *Rate, ?balloon: number) ?{ (Transaction) -> number } -> void
     def ==: (untyped) -> bool
     def balance: () -> decimal
+    def balloon: () -> decimal
     def payment: () -> decimal?
     def principal: () -> decimal
     def rates: () -> Array[Rate]

--- a/spec/finrb/amortization_spec.rb
+++ b/spec/finrb/amortization_spec.rb
@@ -97,7 +97,7 @@ describe(Finrb::Amortization) do
       first = @std.schedule.first
       last = @std.schedule.last
 
-      expect(first.to_h).to(eq(period: 0, opening_balance: D('200000'), payment: D('-926.23'), interest: D('625'), principal: D('301.23'), additional_payment: D('0'), balloon_payment: D('0'), closing_balance: D('199698.77')))
+      expect(first.to_h).to(eq(period: 0, opening_balance: D('200000'), payment: D('-926.23'), interest: D('625'), principal: D('301.23'), additional_payment: D('0'), balloon_payment: D('0'), interest_only: false, closing_balance: D('199698.77')))
       expect(last.closing_balance).to(eq(D('0')))
       expect(@std.schedule.length).to(eq(@std.duration))
     end
@@ -241,6 +241,54 @@ describe(Finrb::Amortization) do
         .to(raise_error(ArgumentError, /balloon/))
       expect { Amortization.new(1000, rate, balloon: 1000) }
         .to(raise_error(ArgumentError, /balloon/))
+    end
+  end
+
+  describe('interest-only periods') do
+    it('defers scheduled principal and amortizes over the remaining term') do
+      rate = Rate.new(0.12, :apr, duration: 12)
+      amortization = Amortization.new(100_000, rate, interest_only_periods: 3)
+      interest_only = amortization.schedule.first(3)
+
+      expect(amortization.payment).to(be_nil)
+      expect(interest_only).to(all(be_interest_only))
+      expect(interest_only).to(all(satisfy { |entry| entry.payment == D('-1000') && entry.principal.zero? }))
+      expect(amortization.schedule[3]).not_to(be_interest_only)
+      expect(amortization.schedule[3].payment).to(eq(D('-11674.04')))
+      expect(amortization.balance).to(be_zero)
+    end
+
+    it('numbers every schedule period sequentially') do
+      rate = Rate.new(0.12, :apr, duration: 12)
+      amortization = Amortization.new(100_000, rate, interest_only_periods: 3)
+
+      expect(amortization.schedule.map(&:period)).to(eq((0...12).to_a))
+    end
+
+    it('combines with a contractual balloon') do
+      rate = Rate.new(0.06, :apr, duration: 12)
+      amortization = Amortization.new(100_000, rate, balloon: 20_000, interest_only_periods: 2)
+
+      expect(amortization.schedule.first(2)).to(all(satisfy { |entry| entry.principal.zero? }))
+      expect(amortization.balloon).to(eq(D('20000')))
+      expect(amortization.schedule.last.balloon_payment).to(be_within(D('0.1')).of(D('20000')))
+      expect(amortization.schedule.sum(&:principal)).to(eq(D('100000')))
+    end
+
+    it('allows zero payments during a zero-rate interest-only phase') do
+      rate = Rate.new(0, :apr, duration: 4)
+      amortization = Amortization.new(1000, rate, interest_only_periods: 2)
+
+      expect(amortization.payments).to(eq([D('0'), D('0'), D('-500'), D('-500')]))
+    end
+
+    it('validates the interest-only duration') do
+      rate = Rate.new(0.05, :apr, duration: 12)
+
+      expect { Amortization.new(1000, rate, interest_only_periods: -1) }
+        .to(raise_error(ArgumentError, /interest_only_periods/))
+      expect { Amortization.new(1000, rate, interest_only_periods: 12) }
+        .to(raise_error(ArgumentError, /interest_only_periods/))
     end
   end
 

--- a/spec/finrb/amortization_spec.rb
+++ b/spec/finrb/amortization_spec.rb
@@ -97,7 +97,7 @@ describe(Finrb::Amortization) do
       first = @std.schedule.first
       last = @std.schedule.last
 
-      expect(first.to_h).to(eq(period: 0, opening_balance: D('200000'), payment: D('-926.23'), interest: D('625'), principal: D('301.23'), additional_payment: D('0'), closing_balance: D('199698.77')))
+      expect(first.to_h).to(eq(period: 0, opening_balance: D('200000'), payment: D('-926.23'), interest: D('625'), principal: D('301.23'), additional_payment: D('0'), balloon_payment: D('0'), closing_balance: D('199698.77')))
       expect(last.closing_balance).to(eq(D('0')))
       expect(@std.schedule.length).to(eq(@std.duration))
     end
@@ -210,6 +210,37 @@ describe(Finrb::Amortization) do
 
     it('has total interest charges of $108880.09') do
       expect(@exp.interest.sum).to(eq(D('108880.09')))
+    end
+  end
+
+  describe('balloon payments') do
+    it('uses the residual principal to calculate lower regular payments') do
+      rate = Rate.new(0.06, :apr, duration: 12)
+      amortization = Amortization.new(100_000, rate, balloon: 50_000)
+
+      expect(amortization.balloon).to(eq(D('50000')))
+      expect(amortization.payment).to(eq(D('-4553.32')))
+      expect(amortization.schedule.last.balloon_payment).to(eq(D('50000')))
+      expect(amortization.schedule.sum(&:balloon_payment)).to(eq(D('50000')))
+      expect(amortization.schedule.sum(&:principal)).to(eq(D('100000')))
+      expect(amortization.balance).to(be_zero)
+    end
+
+    it('supports a balloon on a zero-rate loan') do
+      rate = Rate.new(0, :apr, duration: 3)
+      amortization = Amortization.new(1000, rate, balloon: 400)
+
+      expect(amortization.payments).to(eq([D('-200'), D('-200'), D('-600')]))
+      expect(amortization.schedule.last.balloon_payment).to(eq(D('400')))
+    end
+
+    it('validates the balloon domain') do
+      rate = Rate.new(0.05, :apr, duration: 12)
+
+      expect { Amortization.new(1000, rate, balloon: -1) }
+        .to(raise_error(ArgumentError, /balloon/))
+      expect { Amortization.new(1000, rate, balloon: 1000) }
+        .to(raise_error(ArgumentError, /balloon/))
     end
   end
 

--- a/spec/finrb/amortization_spec.rb
+++ b/spec/finrb/amortization_spec.rb
@@ -9,6 +9,11 @@ describe(Finrb::Amortization) do
   def ipmt(principal, rate, payment, period)
     -(((-rate * principal) * ((rate + 1)**(period - 1))) - (payment * (((rate + 1)**(period - 1)) - 1))).round(2)
   end
+
+  def balanced_schedule_entry?(entry)
+    entry.opening_balance + entry.interest + entry.payment == entry.closing_balance &&
+      entry.opening_balance - entry.principal == entry.closing_balance
+  end
   describe('amortization with a 0% rate') do
     it('does not raise a divide-by-zero error') do
       rate = Rate.new(0, :apr, duration: (30 * 12))
@@ -86,6 +91,30 @@ describe(Finrb::Amortization) do
 
     it('has total interest charges of $133,433.33') do
       expect(@std.interest.sum).to(eq(D('133443.53')))
+    end
+
+    it('exposes an immutable period-by-period schedule') do
+      first = @std.schedule.first
+      last = @std.schedule.last
+
+      expect(first.to_h).to(eq(period: 0, opening_balance: D('200000'), payment: D('-926.23'), interest: D('625'), principal: D('301.23'), additional_payment: D('0'), closing_balance: D('199698.77')))
+      expect(last.closing_balance).to(eq(D('0')))
+      expect(@std.schedule.length).to(eq(@std.duration))
+    end
+
+    it('freezes the schedule and its entries') do
+      expect(@std.schedule).to(be_frozen)
+      expect(@std.schedule.first).to(be_frozen)
+    end
+
+    it('reconciles the schedule to the existing transaction totals') do
+      expect(@std.schedule.sum(&:payment)).to(eq(@std.payments.sum))
+      expect(@std.schedule.sum(&:interest)).to(eq(@std.interest.sum))
+      expect(@std.schedule.sum(&:principal)).to(eq(@std.principal))
+    end
+
+    it('reconciles the balance within every schedule row') do
+      expect(@std.schedule).to(all(satisfy { |entry| balanced_schedule_entry?(entry) }))
     end
   end
 
@@ -172,6 +201,11 @@ describe(Finrb::Amortization) do
 
     it('has total additional payments of $30,084.86') do
       expect(@exp.additional_payments.sum).to(eq(D('-30084.86')))
+    end
+
+    it('identifies user-requested additional principal separately') do
+      expect(@exp.schedule.first.additional_payment).to(eq(D('100')))
+      expect(@exp.schedule.sum(&:additional_payment)).to(eq(D('30084.86')))
     end
 
     it('has total interest charges of $108880.09') do

--- a/spec/finrb/amortization_spec.rb
+++ b/spec/finrb/amortization_spec.rb
@@ -292,6 +292,40 @@ describe(Finrb::Amortization) do
     end
   end
 
+  describe('origination fees') do
+    let(:rate) { Rate.new(0.06, :apr, duration: 12) }
+
+    it('deducts an unfinanced fee from borrower net proceeds') do
+      amortization = Amortization.new(100_000, rate, origination_fee: 2000)
+      without_fee = Amortization.new(100_000, rate)
+
+      expect(amortization.origination_fee).to(eq(D('2000')))
+      expect(amortization.net_proceeds).to(eq(D('98000')))
+      expect(amortization.amount_financed).to(eq(D('100000')))
+      expect(amortization.payment).to(eq(without_fee.payment))
+      expect(amortization).not_to(be_finance_origination_fee)
+    end
+
+    it('adds a financed fee to the amortized opening balance') do
+      amortization = Amortization.new(100_000, rate, origination_fee: 2000, finance_origination_fee: true)
+
+      expect(amortization.net_proceeds).to(eq(D('100000')))
+      expect(amortization.amount_financed).to(eq(D('102000')))
+      expect(amortization.schedule.first.opening_balance).to(eq(D('102000')))
+      expect(amortization.schedule.sum(&:principal)).to(eq(D('102000')))
+      expect(amortization).to(be_finance_origination_fee)
+    end
+
+    it('validates fee amount and financing mode') do
+      expect { Amortization.new(1000, rate, origination_fee: -1) }
+        .to(raise_error(ArgumentError, /origination_fee must be non-negative/))
+      expect { Amortization.new(1000, rate, origination_fee: 1000) }
+        .to(raise_error(ArgumentError, /less than principal/))
+      expect { Amortization.new(1000, rate, finance_origination_fee: :yes) }
+        .to(raise_error(ArgumentError, /true or false/))
+    end
+  end
+
   describe('Numeric Method') do
     it('works with simple invocation') do
       rate = Rate.new(0.0375, :apr, duration: (30 * 12))

--- a/spec/finrb/cashflow_spec.rb
+++ b/spec/finrb/cashflow_spec.rb
@@ -17,6 +17,23 @@ describe(Finrb::Cashflow) do
       expect([-100.0, 60, 60, 60].npv(0.1).round(3)).to(eq(D('49.211')))
     end
 
+    it('calculates modified internal rate of return') do
+      cashflows = [-100, 39, 59, 55, 20]
+
+      result = described_class.mirr(cashflows, finance_rate: 0.1, reinvestment_rate: 0.12)
+      expect(result).to(be_within(D('1e-14')).of(D('0.2043767376745526')))
+      expect(cashflows.mirr(finance_rate: 0.1, reinvestment_rate: 0.12)).to(eq(result))
+    end
+
+    it('validates modified-return cashflows and rates') do
+      expect { described_class.mirr([-100], finance_rate: 0.1, reinvestment_rate: 0.1) }
+        .to(raise_error(Finrb::InvalidCashflowError, /at least two/))
+      expect { described_class.mirr([-100, -20], finance_rate: 0.1, reinvestment_rate: 0.1) }
+        .to(raise_error(Finrb::InvalidCashflowError, /positive and one negative/))
+      expect { described_class.mirr([-100, 120], finance_rate: -1, reinvestment_rate: 0.1) }
+        .to(raise_error(Finrb::DomainError, /greater than -1/))
+    end
+
     it('rejects cashflows without both positive and negative values') do
       expect { [10, 20, 30].irr }
         .to(raise_error(Finrb::InvalidCashflowError))

--- a/spec/finrb/returns_spec.rb
+++ b/spec/finrb/returns_spec.rb
@@ -1,6 +1,42 @@
 # frozen_string_literal: true
 
 describe(Finrb::Returns) do
+  describe('cagr') do
+    it('computes compound annual growth') do
+      result = Returns.cagr(beginning_value: 10_000, ending_value: 16_105.1, periods: 5)
+
+      expect(result).to(be_an_instance_of(Flt::DecNum))
+      expect(result).to(be_within(D('0.0000000001')).of(D('0.1')))
+    end
+
+    it('computes a declining compound rate') do
+      result = Returns.cagr(beginning_value: 100, ending_value: 64, periods: 2)
+
+      expect(result).to(be_within(D('0.0000000001')).of(D('-0.2')))
+    end
+
+    it('represents a total loss as negative one') do
+      expect(Returns.cagr(beginning_value: 100, ending_value: 0, periods: 3)).to(eq(D('-1')))
+    end
+
+    it('requires a positive beginning value') do
+      expect { Returns.cagr(beginning_value: 0, ending_value: 100, periods: 2) }
+        .to(raise_error(ArgumentError, /beginning_value must be greater than zero/))
+    end
+
+    it('rejects a negative ending value') do
+      expect { Returns.cagr(beginning_value: 100, ending_value: -1, periods: 2) }
+        .to(raise_error(ArgumentError, /ending_value must be greater than or equal to zero/))
+    end
+
+    it('requires a positive integer number of periods') do
+      expect { Returns.cagr(beginning_value: 100, ending_value: 110, periods: 0) }
+        .to(raise_error(ArgumentError, /periods must be a positive integer/))
+      expect { Returns.cagr(beginning_value: 100, ending_value: 110, periods: 1.5) }
+        .to(raise_error(ArgumentError, /periods must be a positive integer/))
+    end
+  end
+
   describe('coefficient_variation') do
     it('Example 1') do
       res = Returns.coefficient_variation(sd: 0.15, avg: 0.39)

--- a/spec/finrb/returns_spec.rb
+++ b/spec/finrb/returns_spec.rb
@@ -37,6 +37,92 @@ describe(Finrb::Returns) do
     end
   end
 
+  describe('annualization') do
+    it('compounds periodic returns') do
+      expect(Returns.annualize_return(rate: 0.01, periods_per_year: 12)).to(be_within(D('1e-14')).of(D('0.12682503013196972')))
+    end
+
+    it('scales periodic volatility by the square-root of time') do
+      expect(Returns.annualize_volatility(volatility: 0.02, periods_per_year: 252)).to(be_within(D('1e-14')).of(D('0.31749015732775088')))
+    end
+
+    it('validates annualization inputs') do
+      expect { Returns.annualize_return(rate: -1.01, periods_per_year: 12) }
+        .to(raise_error(ArgumentError, /rate must be greater/))
+      expect { Returns.annualize_volatility(volatility: -0.1, periods_per_year: 12) }
+        .to(raise_error(ArgumentError, /volatility must be greater/))
+      expect { Returns.annualize_return(rate: 0.01, periods_per_year: 0) }
+        .to(raise_error(ArgumentError, /positive integer/))
+    end
+  end
+
+  describe('volatility') do
+    it('computes sample volatility by default') do
+      expect(Returns.volatility(returns: [0.1, 0.2, 0.3])).to(be_within(D('1e-14')).of(D('0.1')))
+    end
+
+    it('computes population volatility when requested') do
+      expect(Returns.volatility(returns: [0.1, 0.2, 0.3], sample: false)).to(be_within(D('1e-14')).of(D('0.08164965809277261')))
+    end
+
+    it('requires enough observations') do
+      expect { Returns.volatility(returns: [], sample: false) }
+        .to(raise_error(ArgumentError, /cannot be empty/))
+      expect { Returns.volatility(returns: [0.1]) }
+        .to(raise_error(ArgumentError, /at least two/))
+      expect { Returns.volatility(returns: [0.1, 0.2], sample: :yes) }
+        .to(raise_error(ArgumentError, /sample must be true or false/))
+    end
+  end
+
+  describe('downside_deviation') do
+    it('uses all observations in the downside-risk denominator') do
+      result = Returns.downside_deviation(returns: [-0.1, 0.05, -0.05])
+
+      expect(result).to(be_within(D('1e-14')).of(D('0.06454972243679028')))
+    end
+
+    it('measures shortfalls relative to a target') do
+      result = Returns.downside_deviation(returns: [0.01, 0.03], target: 0.02)
+
+      expect(result).to(be_within(D('1e-14')).of(D('0.007071067811865476')))
+    end
+  end
+
+  describe('sortino_ratio') do
+    let(:returns) { [-0.1, 0.05, -0.05] }
+
+    it('divides arithmetic excess return by downside deviation') do
+      expect(Returns.sortino_ratio(returns:)).to(be_within(D('1e-14')).of(D('-0.5163977794943222')))
+    end
+
+    it('annualizes the periodic ratio by the square-root of time') do
+      result = Returns.sortino_ratio(returns:, periods_per_year: 12)
+
+      expect(result).to(be_within(D('1e-14')).of(D('-1.7888543819998317')))
+    end
+
+    it('rejects a sequence with no downside risk') do
+      expect { Returns.sortino_ratio(returns: [0.01, 0.02]) }
+        .to(raise_error(ArgumentError, /downside deviation/))
+    end
+  end
+
+  describe('max_drawdown') do
+    it('returns the largest peak-to-trough loss as a positive fraction') do
+      expect(Returns.max_drawdown(values: [100, 120, 90, 150, 105, 140])).to(eq(D('0.3')))
+    end
+
+    it('returns zero for a monotonically increasing series') do
+      expect(Returns.max_drawdown(values: [100, 110, 120])).to(eq(D('0')))
+    end
+
+    it('requires positive portfolio values') do
+      expect { Returns.max_drawdown(values: [100, 0]) }
+        .to(raise_error(ArgumentError, /greater than zero/))
+    end
+  end
+
   describe('coefficient_variation') do
     it('Example 1') do
       res = Returns.coefficient_variation(sd: 0.15, avg: 0.39)

--- a/spec/finrb_spec.rb
+++ b/spec/finrb_spec.rb
@@ -2,7 +2,7 @@
 
 describe(Finrb) do
   it('exposes the gem version') do
-    expect(described_class::VERSION).to(eq('1.0.1'))
+    expect(described_class::VERSION).to(eq('1.1.0'))
   end
 
   describe('decimal interoperability') do


### PR DESCRIPTION
## 1.1.0

### Investment returns and risk

- Add compound annual growth rate (CAGR) with explicit value and period-domain validation.
- Add modified internal rate of return (MIRR) with separate financing and reinvestment rates.
- Add sample and population volatility, downside deviation, Sortino ratio, and maximum drawdown.
- Add compound-return and square-root-of-time volatility annualization helpers.
- Define the statistical conventions explicitly: volatility is sample-based by default, downside deviation includes all observations in its denominator, and maximum drawdown is returned as a non-negative loss fraction.

### Loan schedules

- Expose each amortization period as an immutable `Finrb::Amortization::Entry` containing its period, opening and closing balances, payment, interest, principal, additional principal, balloon settlement, and interest-only state.
- Preserve the existing cashflow convention: payments are negative, while balances, interest, principal repaid, and additional principal are non-negative.
- Add contractual balloon targets. Regular installments amortize toward the target and the final payment settles the residual, including cent-rounding reconciliation.
- Add leading interest-only periods, including zero-rate periods and combinations with balloon loans. Remaining principal amortizes over the rest of the term.
- Add upfront and financed origination fees with separate `principal`, `net_proceeds`, and `amount_financed` values. Financed fees enter the opening balance; upfront fees reduce borrower proceeds.
- Correct schedule period numbering across rate segments and reused payment templates.

### API and documentation

- Add RBS declarations and API examples for all new return metrics and amortization features.
- Refine README compatibility badges to identify tested MRI versions, x86-64/ARM64 architectures, and experimental JRuby/TruffleRuby coverage.
- Remove redundant YARD `@api` annotations and make the internal amortization calculation methods genuinely private.