### PR TITLE
finrb [Release]: Prepare version 1.2.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ to keep the conversation linked together. -->
 request, mention that information here. This could include
 benchmarks, or other information.
 
-If you are updating any of the CHANGELOG files or are asked to update the
-CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.
+Do not add an unreleased changelog section for ordinary development work. The
+maintainer prepares the changelog when assembling a release.
 
 Thanks for contributing to finrb! -->

--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 1
-:minor: 1
+:minor: 2
 :patch: 0
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # finrb changelog
 
+## 1.2.0
+
+### Validation and financial correctness
+
+- Apply the shared finite-decimal validation contract across yields, returns,
+  accounting, ratios, cashflows, rates, amortization, and TVM helpers.
+- Replace abbreviated validation errors with descriptive financial terms such
+  as period count, future value, face value, and compounding periods.
+- Add explicit denominator, rate, share-count, inventory, useful-life, and
+  residual-value domain checks while preserving valid decimal calculations and
+  return types.
+- Fix LIFO ending-inventory retention when a sale is satisfied by the second
+  purchase layer, preserving inventory cost conservation.
+- Reject invalid weighted-return vectors and replace the previous unsolicited
+  weighted-portfolio warning with an explicit validation error.
+
+### Development and project maintenance
+
+- Add deterministic `benchmark:run` scenarios using `benchmark-ips` for IRR,
+  XIRR, and amortization scaling, with known-root, equation-residual, solver
+  evaluation, and schedule-reconciliation preflight diagnostics.
+- Add contributor and security guidance, and link the project entry documents
+  from the README.
+- Include contributor and security documentation in packaged gem metadata.
+
 ## 1.1.0
 
 ### Investment returns and risk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to finrb
+
+finrb welcomes focused bug fixes, documentation improvements, tests, and
+financial calculations that fit the project's scope. Before starting a large
+feature or public API change, open an issue so its financial conventions and
+design can be agreed upon first.
+
+## Development setup
+
+finrb requires Ruby 3.3 or newer. MRI 3.3, 3.4, and 4.0 are supported; JRuby
+and TruffleRuby are tested as informational compatibility targets.
+
+```shell
+bundle install
+bundle exec rake quality
+bundle exec rubocop
+```
+
+`rake quality` runs the RSpec suite with coverage, verifies maintained API
+examples, and validates the packaged RBS declarations. Additional checks are
+available for changes that affect their domains:
+
+```shell
+bundle exec rake security:audit
+bundle exec rake package:verify
+bundle exec rake benchmark:run
+bundle exec rake solver:verify
+```
+
+The solver verification task requires the optional Python environment
+documented in [spec/fixtures/README.md](spec/fixtures/README.md). The Python
+packages are development references and are not gem dependencies.
+
+## Making changes
+
+- Preserve unrelated code and behavior. Keep pull requests small enough to
+  review their financial and numerical consequences directly.
+- Follow the local Ruby style and run RuboCop. Comments should explain a
+  non-obvious reason or convention, not restate the code.
+- Route public numeric inputs through `Finrb::Validation`. Use `ArgumentError`
+  for malformed inputs and namespaced finrb errors for financial or numerical
+  domains.
+- Preserve `Flt::DecNum` calculations and return types unless the change has a
+  documented compatibility reason.
+- Update RBS declarations and user documentation when a public contract
+  changes.
+- Do not add an unreleased changelog section for ordinary development work.
+  The maintainer prepares the changelog as part of an actual release.
+
+## Numerical and financial changes
+
+A formula compiling or producing a plausible number is not sufficient
+verification. Describe the convention being implemented and test the relevant
+invariants, boundaries, and failure modes.
+
+For a solver or precision-sensitive change, include as appropriate:
+
+- known-root or algebraically constructed cases;
+- normalized equation residuals;
+- zero, negative-rate, long-horizon, and scale-sensitive cases;
+- attributable fixtures from a reputable independent implementation under
+  matching financial conventions;
+- deterministic seeds for generated cases; and
+- benchmarks that compare the same scenario across revisions, runtimes, or
+  architectures rather than ranking unrelated calculations.
+
+Reference fixtures must record their source, version, conventions, generation
+method, and tolerance. Do not replace committed fixtures merely to make a
+changed implementation pass without explaining why the reference changed.
+
+## Pull requests
+
+Use the pull request template and include:
+
+- the financial or technical problem;
+- the intended contract and compatibility impact;
+- the evidence used to verify correctness; and
+- any checks skipped because an optional runtime or external reference was
+  unavailable.
+
+Commit subjects in this repository commonly use the form
+`domain [Category]: Imperative summary`, for example:
+
+```text
+cashflows [Fix]: Preserve negative-root selection
+```
+
+By contributing, you agree that your work is provided under the repository's
+LGPL-3.0-or-later license.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    finrb (1.1.0)
+    finrb (1.2.0)
       bigdecimal (>= 3.1.2)
       flt
       ostruct

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
   specs:
     amazing_print (2.0.0)
     ast (2.4.3)
+    benchmark-ips (2.15.1)
     bigdecimal (4.1.2)
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
@@ -37,7 +38,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -57,8 +58,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.89.0)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)
@@ -100,6 +101,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  benchmark-ips
   bundler-audit
   finrb!
   pry

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ API explicitly returns another financial object, such as `Finrb::Rate`.
 | `Finrb::Ratios` | Liquidity, leverage, profitability, and per-share ratios |
 | `Finrb::Accounting` | Inventory costing and depreciation |
 
-The detailed [API and examples guide](docs/api.md) lists each calculation and
-its parameters. Packaged RBS declarations are available under `sig/`.
+The [API and examples guide](docs/api.md) documents each financial domain and
+its public calculations. Packaged RBS declarations are available under `sig/`.
 
 ## Cashflows
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Docker, batching, and tolerance details.
 - [RubyGems](https://rubygems.org/gems/finrb)
 - [Source](https://github.com/ncs1/finrb)
 - [Issue tracker](https://github.com/ncs1/finrb/issues)
+- [Contributing](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
 
 ## Acknowledgements
 

--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,14 @@ namespace :solver do
   end
 end
 
+namespace :benchmark do
+  desc 'Benchmark IRR, XIRR, and amortization with correctness diagnostics'
+  task :run do
+    arguments = ['--time', ENV.fetch('TIME', '2'), '--warmup', ENV.fetch('WARMUP', '1'), '--seed', ENV.fetch('SEED', '20260826')]
+    sh(RbConfig.ruby, File.join(__dir__, 'script', 'benchmark_finrb.rb'), *arguments)
+  end
+end
+
 namespace :docker do
   alternative_dockerfile = 'Dockerfile.engines'
   alternative_images = { jruby: ENV.fetch('JRUBY_IMAGE', 'jruby:10-jdk21'), truffleruby: ENV.fetch('TRUFFLERUBY_IMAGE', 'ghcr.io/graalvm/truffleruby-community:latest') }

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rake'
+require 'rbconfig'
 require 'rspec/core/rake_task'
 
 task(:spec).clear
@@ -20,7 +21,14 @@ ensure
 end
 
 desc 'Run all self-contained quality checks'
-task quality: %i[coverage rbs:validate]
+task quality: %i[coverage docs:verify rbs:validate]
+
+namespace :docs do
+  desc 'Execute marked Ruby examples from the API guide'
+  task :verify do
+    sh(RbConfig.ruby, File.join(__dir__, 'script', 'verify_markdown_examples.rb'), 'docs/api.md')
+  end
+end
 
 namespace :rbs do
   desc 'Validate packaged RBS signatures'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made against the current released finrb line. Older
+versions may receive a fix when practical, but they are not guaranteed to be
+maintained. Users should reproduce an issue on the newest release before
+reporting it when possible.
+
+JRuby and TruffleRuby are informational compatibility targets. A
+runtime-specific vulnerability may also need to be reported to the relevant
+Ruby implementation or dependency maintainers.
+
+## Reporting a vulnerability
+
+Do not disclose a suspected vulnerability in a public issue, discussion, or
+pull request. Use GitHub's private vulnerability reporting for finrb:
+
+<https://github.com/ncs1/finrb/security/advisories/new>
+
+If private reporting is unavailable, contact the maintainer through the email
+listed in the gem metadata. Include only enough information in the initial
+message to establish a private channel.
+
+A useful report contains:
+
+- affected finrb and Ruby versions;
+- the affected API or packaged artifact;
+- minimal reproduction steps;
+- the expected and observed impact; and
+- any known mitigations or disclosure constraints.
+
+Please avoid including production credentials, private financial data, access
+tokens, or other secrets. There is no guaranteed response or remediation
+timeline; this project is maintained by one person. Reports will be evaluated
+according to reproducibility, impact, and available maintainer capacity.
+
+Numerical disagreement alone is normally a correctness bug rather than a
+security vulnerability. Treat it as security-sensitive when it can cross a
+trust boundary, bypass validation, enable denial of service, corrupt packaged
+artifacts, or predictably cause unsafe downstream financial decisions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,1344 +1,276 @@
-# finrb - API and examples
+# finrb API and examples
 
-<!-- TOC -->
+This guide documents finrb's public, namespaced API. All calculations use
+`Flt::DecNum` decimal values unless a method explicitly returns another object.
+The packaged [RBS declarations](../sig/finrb.rbs) provide the complete machine-
+readable method signatures.
 
-- [Amortization](#amortization)
-- [IRR and XIRR](#irr-and-xirr)
-  - [Modified internal rate of return](#modified-internal-rate-of-return)
-- [Financial calculations](#financial-calculations)
-  - [Computing bank discount yield BDY for a T-bill](#computing-bank-discount-yield-bdy-for-a-t-bill)
-  - [Computing money market yield MMY for a T-bill](#computing-money-market-yield-mmy-for-a-t-bill)
-  - [Cash ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due](#cash-ratio---liquidity-ratios-measure-the-firms-ability-to-satisfy-its-short-term-obligations-as-they-come-due)
-  - [Computing Coefficient of variation](#computing-coefficient-of-variation)
-  - [Cost of goods sold and ending inventory under three methods FIFO,LIFO,Weighted average](#cost-of-goods-sold-and-ending-inventory-under-three-methods-fifolifoweighted-average)
-  - [Current ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due](#current-ratio---liquidity-ratios-measure-the-firms-ability-to-satisfy-its-short-term-obligations-as-they-come-due)
-  - [Depreciation Expense Recognition - double-declining balance DDB, the most common declining balance method, which applies two times the straight-line rate to the declining balance](#depreciation-expense-recognition---double-declining-balance-ddb-the-most-common-declining-balance-method-which-applies-two-times-the-straight-line-rate-to-the-declining-balance)
-  - [Debt ratio - Solvency ratios measure the firm's ability to satisfy its long-term obligations](#debt-ratio---solvency-ratios-measure-the-firms-ability-to-satisfy-its-long-term-obligations)
-  - [Diluted Earnings Per Share](#diluted-earnings-per-share)
-  - [Computing the rate of return for each period](#computing-the-rate-of-return-for-each-period)
-  - [Convert stated annual rate to the effective annual rate](#convert-stated-annual-rate-to-the-effective-annual-rate)
-  - [Convert stated annual rate to the effective annual rate with continuous compounding](#convert-stated-annual-rate-to-the-effective-annual-rate-with-continuous-compounding)
-  - [Bond-equivalent yield BEY, 2 x the semiannual discount rate](#bond-equivalent-yield-bey-2-x-the-semiannual-discount-rate)
-  - [Computing HPR, the holding period return](#computing-hpr-the-holding-period-return)
-  - [Equivalent/proportional Interest Rates](#equivalentproportional-interest-rates)
-  - [Basic Earnings Per Share](#basic-earnings-per-share)
-  - [Financial leverage - Solvency ratios measure the firm's ability to satisfy its long-term obligations](#financial-leverage---solvency-ratios-measure-the-firms-ability-to-satisfy-its-long-term-obligations)
-  - [Estimate future value fv](#estimate-future-value-fv)
-  - [Estimate future value of an annuity](#estimate-future-value-of-an-annuity)
-  - [Estimate future value fv of a single sum](#estimate-future-value-fv-of-a-single-sum)
-  - [Computing the future value of an uneven cash flow series](#computing-the-future-value-of-an-uneven-cash-flow-series)
-  - [Compound annual growth rate](#compound-annual-growth-rate)
-  - [Risk and annualization helpers](#risk-and-annualization-helpers)
-  - [Geometric mean return](#geometric-mean-return)
-  - [Gross profit margin - Evaluate a company's financial performance](#gross-profit-margin---evaluate-a-companys-financial-performance)
-  - [Harmonic mean, average price](#harmonic-mean-average-price)
-  - [Computing HPR, the holding period return](#computing-hpr-the-holding-period-return)
-  - [Bond-equivalent yield BEY, 2 x the semiannual discount rate](#bond-equivalent-yield-bey-2-x-the-semiannual-discount-rate)
-  - [Convert holding period return to the effective annual rate](#convert-holding-period-return-to-the-effective-annual-rate)
-  - [Computing money market yield MMY for a T-bill](#computing-money-market-yield-mmy-for-a-t-bill)
-  - [Calculate the net increase in common shares from the potential exercise of stock options or warrants](#calculate-the-net-increase-in-common-shares-from-the-potential-exercise-of-stock-options-or-warrants)
-  - [Long-term debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations](#long-term-debt-to-equity---solvency-ratios-measure-the-firms-ability-to-satisfy-its-long-term-obligations)
-  - [Computing HPR, the holding period return](#computing-hpr-the-holding-period-return)
-  - [Estimate the number of periods](#estimate-the-number-of-periods)
-  - [Net profit margin - Evaluate a company's financial performance](#net-profit-margin---evaluate-a-companys-financial-performance)
-  - [Computing NPV, the PV of the cash flows less the initial time = 0 outlay](#computing-npv-the-pv-of-the-cash-flows-less-the-initial-time--0-outlay)
-  - [Estimate period payment](#estimate-period-payment)
-  - [Estimate present value pv](#estimate-present-value-pv)
-  - [Estimate present value pv of an annuity](#estimate-present-value-pv-of-an-annuity)
-  - [Estimate present value of a perpetuity](#estimate-present-value-of-a-perpetuity)
-  - [Estimate present value pv of a single sum](#estimate-present-value-pv-of-a-single-sum)
-  - [Computing the present value of an uneven cash flow series](#computing-the-present-value-of-an-uneven-cash-flow-series)
-  - [Quick ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due](#quick-ratio---liquidity-ratios-measure-the-firms-ability-to-satisfy-its-short-term-obligations-as-they-come-due)
-  - [Convert a given norminal rate to a continuous compounded rate](#convert-a-given-norminal-rate-to-a-continuous-compounded-rate)
-  - [Convert a given continuous compounded rate to a norminal rate](#convert-a-given-continuous-compounded-rate-to-a-norminal-rate)
-  - [Rate of return for a perpetuity](#rate-of-return-for-a-perpetuity)
-  - [Computing Sampling error](#computing-sampling-error)
-  - [Computing Roy's safety-first ratio](#computing-roys-safety-first-ratio)
-  - [Computing Sharpe Ratio](#computing-sharpe-ratio)
-  - [Depreciation Expense Recognition - Straight-line depreciation SL allocates an equal amount of depreciation each year over the asset's useful life](#depreciation-expense-recognition---straight-line-depreciation-sl-allocates-an-equal-amount-of-depreciation-each-year-over-the-assets-useful-life)
-  - [Total debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations](#total-debt-to-equity---solvency-ratios-measure-the-firms-ability-to-satisfy-its-long-term-obligations)
-  - [Computing TWRR, the time-weighted rate of return](#computing-twrr-the-time-weighted-rate-of-return)
-  - [Calculate weighted average shares - weighted average number of common shares](#calculate-weighted-average-shares---weighted-average-number-of-common-shares)
-  - [Weighted mean as a portfolio return](#weighted-mean-as-a-portfolio-return)
+Examples marked “verified” are executed in isolated Ruby processes by
+`bundle exec rake docs:verify` and by the normal `quality` task.
 
-<!-- /TOC -->
-## Amortization
+## Rates
 
-Amortization treats payments and period interest as monetary postings. Each is
-rounded to two decimal places using `Finrb::Precision.money`, which applies
-half-up rounding. Any final balance caused by period-by-period cent rounding is
-allocated to the last payment. Other financial calculations retain decimal
-precision unless their API explicitly states otherwise.
+`Finrb::Rate` distinguishes nominal annual percentage rates from effective
+annual yields. `duration` is expressed in months for amortization.
 
-You are interested in borrowing $250,000 under a 30 year, fixed-rate
-loan with a 4.25% APR.
+<!-- verify-example -->
+```ruby
+rate = Finrb::Rate.new(0.12, :apr, duration: 360)
+
+raise unless rate.apr == Flt::DecNum('0.12')
+raise unless rate.monthly == Flt::DecNum('0.01')
+raise unless rate.apy.round(6) == Flt::DecNum('0.126825')
+```
+
+An effective rate converts to the periodic rate that compounds back to the
+same annual yield; it is not divided by twelve.
 
 ```ruby
-rate = Finrb::Rate.new(0.0425, :apr, :duration => (30 * 12))
-amortization = Finrb::Amortization.new(250000, rate)
+Finrb::Rate.new(0.12, :apy)
+Finrb::Rate.new(0.05, :nominal, compounds: :quarterly)
+Finrb::Rate.new(0.05, :effective, compounds: :annually)
 ```
 
-The immutable schedule exposes the accounting breakdown for each period:
+Class conversions:
 
+- `Finrb::Rate.to_effective(nominal_rate, periods)`
+- `Finrb::Rate.to_nominal(effective_rate, periods)`
+
+## Cashflows
+
+Periodic cashflows are equally spaced. IRR returns a per-period rate and NPV
+accepts a per-period discount rate.
+
+<!-- verify-example -->
 ```ruby
-entry = amortization.schedule.first
+cashflows = [-4000, 1200, 1410, 1875, 1050]
+rate = Finrb::Cashflow.irr(cashflows)
 
-entry.period
-entry.opening_balance
-entry.payment
-entry.interest
-entry.principal
-entry.additional_payment
-entry.balloon_payment
-entry.interest_only?
-entry.closing_balance
+raise unless rate.round(6) == Flt::DecNum('0.142993')
+raise unless Finrb::Cashflow.npv(cashflows, 0.10).round(2) == Flt::DecNum('382.08')
 ```
 
-Payments use finrb's negative cash-outflow convention. The other monetary
-fields are non-negative. Consequently, every row satisfies:
+MIRR separates the rate paid to finance negative cashflows from the rate earned
+by reinvesting positive cashflows.
 
-```text
-opening_balance + interest + payment = closing_balance
-opening_balance - principal = closing_balance
-```
-
-The schedule array and every `Finrb::Amortization::Entry` are frozen. Final
-payment reconciliation is reflected in the last row.
-
-A balloon is a residual principal target used when calculating regular
-installments and then settled as part of the final payment:
-
+<!-- verify-example -->
 ```ruby
-balloon_loan = Finrb::Amortization.new(250_000, rate, balloon: 100_000)
-balloon_loan.payment
-balloon_loan.schedule.last.balloon_payment # => Flt::DecNum('100000')
-balloon_loan.balance                       # => Flt::DecNum('0')
-```
-
-`balloon` retains the contractual residual target. Since regular payments are
-rounded to cents, the final row's actual `balloon_payment` can differ from the
-target by a small rounding remainder.
-
-Leading interest-only periods pay accrued interest without scheduled principal
-and then amortize the balance over the remaining periods. They can be combined
-with a balloon:
-
-```ruby
-loan = Finrb::Amortization.new(
-  250_000,
-  rate,
-  interest_only_periods: 24,
-  balloon: 50_000
-)
-
-loan.schedule.first.interest_only? # => true
-loan.schedule.first.principal      # => Flt::DecNum('0')
-```
-
-Origination fees are kept separate from interest and principal. By default the
-fee is paid from the loan proceeds, reducing the cash available to the borrower
-without changing scheduled payments:
-
-```ruby
-loan = Finrb::Amortization.new(250_000, rate, origination_fee: 2_500)
-loan.principal        # => Flt::DecNum('250000')
-loan.net_proceeds     # => Flt::DecNum('247500')
-loan.amount_financed  # => Flt::DecNum('250000')
-```
-
-With `finance_origination_fee: true`, the borrower receives the stated
-principal and the fee is added to the opening balance:
-
-```ruby
-loan = Finrb::Amortization.new(
-  250_000,
-  rate,
-  origination_fee: 2_500,
-  finance_origination_fee: true
-)
-
-loan.net_proceeds                    # => Flt::DecNum('250000')
-loan.amount_financed                 # => Flt::DecNum('252500')
-loan.schedule.first.opening_balance  # => Flt::DecNum('252500')
-```
-
-Find the standard monthly payment:
-
-```ruby
-amortization.payment
-=> Flt::DecNum('-1229.91')
-```
-
-Find the total cost of the loan:
-
-```ruby
-amortization.payments.sum
-=> Flt::DecNum('-442766.55')
-```
-
-How much will you pay in interest?
-
-```ruby
-amortization.interest.sum
-=> Flt::DecNum('192766.55')
-```
-
-How much interest in the first six months?
-
-```ruby
-amortization.interest[0,6].sum
-=> Flt::DecNum('5294.62')
-```
-
-If your loan has an adjustable rate, no problem. You can pass an
-arbitrary number of rates, and they will be used in the amortization.
-For example, we can look at an amortization of $250000, where the APR
-starts at 4.25%, and increases by 1% every five years.
-
-```ruby
-values = %w{ 0.0425 0.0525 0.0625 0.0725 0.0825 0.0925 }
-rates = values.collect { |value| Finrb::Rate.new( value, :apr, :duration => (5  * 12) }
-arm = Finrb::Amortization.new(250000, *rates)
-```
-
-Since we are looking at an ARM, there is no longer a single "payment" value.
-
-```ruby
-arm.payment
-=> nil
-```
-
-But we can look at the different payments over time.
-
-```ruby
-arm.payments.uniq
-=> [Flt::DecNum('-1229.85'), Flt::DecNum('-1360.41'), Flt::DecNum('-1475.65'), Flt::DecNum('-1571.07'), ... snipped ... ]
-```
-
-The other methods previously discussed can be accessed in the same way:
-
-```ruby
-arm.interest.sum
-=> Flt::DecNum('287515.45')
-arm.payments.sum
-=> Flt::DecNum('-537515.45')
-```
-
-Last, but not least, you may pass a block when creating an Amortization
-which returns a modified monthly payment. For example, to increase your
-payment by $150, do:
-
-```ruby
-rate = Finrb::Rate.new(0.0425, :apr, :duration => (30 * 12))
-extra_payments = Finrb::Amortization.new(250000, rate){ |period| period.payment - 150 }
-```
-
-Disregarding the block, we have used the same parameters as the first
-example. Notice the difference in the results:
-
-```ruby
-amortization.payments.sum
-=> Flt::DecNum('-442745.98')
-extra_payments.payments.sum
-=> Flt::DecNum('-400566.24')
-amortization.interest.sum
-=> Flt::DecNum('192745.98')
-extra_payments.interest.sum
-=> Flt::DecNum('150566.24')
-```
-
-You can also increase your payment to a specific amount:
-
-```ruby
-extra_payments_2 = Finrb::Amortization.new(250000, rate){ -1500 }
-```
-
-The legacy `Array#irr`, `Array#xirr`, and `Numeric#amortize` forms are
-available only after explicitly loading `finrb/core_ext`. Loading `finrb`
-alone leaves Ruby's core classes unchanged.
-
-## IRR and XIRR
-
-`irr` solves for the per-period rate that makes the net present value of an
-ordered sequence of equally spaced cashflows equal to zero:
-
-```text
-sum(cashflow[t] / (1 + rate)^t) = 0
-```
-
-```ruby
-Finrb::Cashflow.irr([-4000, 1200, 1410, 1875, 1050])
-# => Flt::DecNum('0.142993...')
-```
-
-The first entry is period zero, the second is period one, and so on. Inputs
-must contain both a positive and a negative cashflow. The result is an
-`Flt::DecNum` per-period rate.
-
-`xirr` applies the same idea to irregularly dated `Finrb::Transaction`
-objects. Under the default configuration, exponents use actual calendar days
-divided by 365 and the result is an effective annual `Finrb::Rate`:
-
-```ruby
-transactions = [
-  Finrb::Transaction.new(-10_000, date: Date.new(2010, 1, 1)),
-  Finrb::Transaction.new(12_300, date: Date.new(2012, 1, 1))
-]
-
-rate = Finrb::Cashflow.xirr(transactions, 0.1)
-rate.effective
-# => Flt::DecNum('0.10905...')
-```
-
-Transactions are evaluated in the supplied order and date offsets are
-measured from the first transaction. Supply them chronologically, with every
-transaction having a `Date`, `Time`, or another date value that responds to
-`to_date`. As with `irr`, the amounts must contain both signs. Valid discrete
-rates are greater than `-1` (greater than -100%).
-
-### Modified internal rate of return
-
-MIRR avoids IRR's implicit assumption that every intermediate inflow is
-reinvested at the computed IRR. It discounts negative cashflows using the
-financing rate and compounds positive cashflows using the reinvestment rate:
-
-```ruby
-Finrb::Cashflow.mirr(
+rate = Finrb::Cashflow.mirr(
   [-100, 39, 59, 55, 20],
   finance_rate: 0.10,
   reinvestment_rate: 0.12
 )
-# => Flt::DecNum('0.204376...')
+
+raise unless rate.round(6) == Flt::DecNum('0.204377')
 ```
 
-Cashflows are equally spaced and must contain at least one positive and one
-negative amount. Both rates must be greater than `-1`.
+XIRR and XNPV accept chronological `Finrb::Transaction` objects. The default
+date convention is actual calendar days divided by 365.
 
-### Guess and multiple roots
-
-The optional guess is not merely a performance hint. A non-conventional
-cashflow can have multiple valid IRRs, and finrb selects the sign-changing root
-nearest the guess it can bracket. If omitted, the guess comes from
-`Finrb.config.guess`.
-
+<!-- verify-example -->
 ```ruby
-cashflows = [-100, 230, -132] # roots at 10% and 20%
+transactions = [
+  Finrb::Transaction.new(-10_000, date: Date.new(2020, 1, 1)),
+  Finrb::Transaction.new(12_500, date: Date.new(2022, 1, 1))
+]
 
-Finrb::Cashflow.irr(cashflows, 0.05) # => approximately 0.10
-Finrb::Cashflow.irr(cashflows, 0.25) # => approximately 0.20
+rate = Finrb::Cashflow.xirr(transactions, 0.10)
+raise unless rate.apy.round(6) == Flt::DecNum('0.117863')
+raise unless Finrb::Cashflow.xnpv(transactions, rate.apy).abs < Flt::DecNum('1e-10')
 ```
 
-An even-multiplicity root only touches zero rather than crossing it, so a
-bracketing search cannot generally discover it. Finrb returns such a root only
-when the supplied guess evaluates exactly to that root:
+Cashflows must include at least one positive and one negative amount. Discrete
+rates and guesses must be greater than `-1`. Multiple IRRs can exist; the
+optional guess selects the nearby sign-changing root finrb attempts to bracket.
 
+## Amortization
+
+Rates used in amortization require a duration in months. Payments are negative
+cash outflows; balances, interest, and principal repaid are non-negative.
+
+<!-- verify-example -->
 ```ruby
-cashflows = [1, -2.2, 1.21] # repeated root at 10%
+rate = Finrb::Rate.new(0.0425, :apr, duration: 30 * 12)
+loan = Finrb::Amortization.new(250_000, rate)
+first = loan.schedule.first
 
-Finrb::Cashflow.irr(cashflows, 0.1) # => approximately 0.10
-Finrb::Cashflow.irr(cashflows, 0.0) # raises Finrb::ConvergenceError
+raise unless loan.payment == Flt::DecNum('-1229.85')
+raise unless first.opening_balance == Flt::DecNum('250000')
+raise unless first.opening_balance + first.interest + first.payment == first.closing_balance
+raise unless loan.schedule.last.closing_balance.zero?
 ```
 
-### Precision and failures
+Each frozen `Finrb::Amortization::Entry` exposes:
 
-Calculations use `Flt::DecNum`. `Finrb.config.eps`, which defaults to
-`1.0e-16`, controls both the absolute and relative bracket-width tolerance.
-The returned value therefore satisfies the configured numerical stopping
-criterion; its displayed digits should not be interpreted as guaranteed
-economic accuracy beyond the cashflow inputs.
+- `period`, `opening_balance`, and `closing_balance`;
+- `payment`, `interest`, and `principal`;
+- `additional_payment` and `balloon_payment`;
+- `interest_only?`.
 
-- `Finrb::InvalidCashflowError` is raised when the cashflows do not contain
-  both positive and negative amounts.
-- `ArgumentError` is raised for a non-numeric guess.
-- `Finrb::DomainError` is raised when the guess is at or below `-1`, or the
-  rate function is undefined or non-finite.
-- `Finrb::ConvergenceError` is raised when no sign-changing root can be
-  bracketed or the numerical solver does not converge.
+Balloon targets, interest-only periods, and origination fees compose in one
+schedule. An upfront fee reduces net proceeds; a financed fee increases the
+opening balance.
 
-The `business_days` and `periodic_compound` configuration options alter XIRR's
-date and compounding conventions. They are compatibility options, not market
-holiday calendars; `business_days` excludes weekends only.
-```
-
-## Financial calculations
-
-The following functions are grouped by their owning financial modules.
-
-Several calculations originated in R's [FinCal](https://github.com/felixfan/FinCal) library (ported to Ruby).
-
-Provides the following functions:
-
-- Basic Earnings Per Share
-
-- Bond-equivalent yield (BEY), 2 x the semiannual discount rate
-
-- Calculate the net increase in common shares from the potential exercise of stock options or warrants
-
-- Calculate weighted average shares - weighted average number of common shares
-
-- Cash ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due.
-
-- Computing Coefficient of variation
-
-- Computing HPR, the holding period return
-
-- Computing NPV, the PV of the cash flows less the initial (time = 0) outlay
-
-- Computing Roy's safety-first ratio
-
-- Computing Sampling error
-
-- Computing Sharpe Ratio
-
-- Computing TWRR, the time-weighted rate of return
-
-- Computing bank discount yield (BDY) for a T-bill
-
-- Computing money market yield (MMY) for a T-bill
-
-- Computing the future value of an uneven cash flow series
-
-- Computing the present value of an uneven cash flow series
-
-- Computing the rate of return for each period
-
-- Convert a given continuous compounded rate to a norminal rate
-
-- Convert a given norminal rate to a continuous compounded rate
-
-- Convert holding period return to the effective annual rate
-
-- Convert stated annual rate to the effective annual rate (with continuous compounding)
-
-- Cost of goods sold and ending inventory under three methods (FIFO,LIFO,Weighted average)
-
-- Current ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due.
-
-- Debt ratio - Solvency ratios measure the firm's ability to satisfy its long-term obligations.
-
-- Depreciation Expense Recognition - Straight-line depreciation (SL) allocates an equal amount of depreciation each year over the asset's useful life
-
-- Depreciation Expense Recognition - double-declining balance (DDB), the most common declining balance method, which applies two times the straight-line rate to the declining balance.
-
-- Diluted Earnings Per Share
-
-- Equivalent/proportional Interest Rates
-
-- Estimate future value (fv) (of a single sum)
-
-- Estimate future value of an annuity
-
-- Estimate period payment
-
-- Estimate present value (pv) (of a single sum) (of an annuity)
-
-- Estimate present value of a perpetuity
-
-- Estimate the number of periods
-
-- Financial leverage - Solvency ratios measure the firm's ability to satisfy its long-term obligations.
-
-- Geometric mean return
-
-- Gross profit margin - Evaluate a company's financial performance
-
-- Harmonic mean, average price
-
-- Long-term debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations.
-
-- Net profit margin - Evaluate a company's financial performance
-
-- Quick ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due.
-
-- Rate of return for a perpetuity
-
-- Total debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations.
-
-- Weighted mean as a portfolio return
-
-### Computing bank discount yield (BDY) for a T-bill
-
-- Param - d - the dollar discount, which is equal to the difference between the face value of the bill and the purchase price
-
-- Param - f - the face value (par value) of the bill
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
+<!-- verify-example -->
 ```ruby
-Finrb::Yields.bdy(d=1500,f=100000,t=120)
-```
-
-### Computing money market yield (MMY) for a T-bill
-
-- Param - bdy - bank discount yield
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.bdy2mmy(bdy=0.045,t=120)
-```
-
-### Cash ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due
-
-- Param - cash - cash
-
-- Param - ms - marketable securities
-
-- Param - cl - current liabilities
-
-Examples:
-
-```ruby
-Finrb::Ratios.cash_ratio(cash=3000,ms=2000,cl=2000)
-```
-
-### Computing Coefficient of variation
-
-- Param - sd - standard deviation
-
-- Param - avg - average value
-
-Examples:
-
-```ruby
-Finrb::Returns.coefficient_variation(sd=0.15,avg=0.39)
-```
-
-### Cost of goods sold and ending inventory under three methods (FIFO,LIFO,Weighted average)
-
-- Param - uinv - units of beginning inventory
-
-- Param - pinv - price of beginning inventory
-
-- Param - units - nx1 vector of inventory units. inventory purchased ordered by time (from first to last)
-
-- Param - price - nx1 vector of inventory price. same order as units
-
-- Param - sinv - units of sold inventory
-
-- Param - method - inventory methods: FIFO (first in first out, permitted under both US and IFRS), LIFO (late in first out, US only), WAC (weighted average cost,US and IFRS)
-
-Examples:
-
-```ruby
-Finrb::Accounting.cogs(uinv=2,pinv=2,units=[3,5],price=[3,5],sinv=7,method="FIFO")
-```
-
-```ruby
-Finrb::Accounting.cogs(uinv=2,pinv=2,units=[3,5],price=[3,5],sinv=7,method="LIFO")
-```
-
-```ruby
-Finrb::Accounting.cogs(uinv=2,pinv=2,units=[3,5],price=[3,5],sinv=7,method="WAC")
-```
-
-### Current ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due
-
-- Param - ca - current assets
-
-- Param - cl - current liabilities
-
-Examples:
-
-```ruby
-Finrb::Ratios.current_ratio(ca=8000,cl=2000)
-```
-
-### Depreciation Expense Recognition - double-declining balance (DDB), the most common declining balance method, which applies two times the straight-line rate to the declining balance
-
-- Param - cost - cost of long-lived assets
-
-- Param - rv - residual value of the long-lived assets at the end of its useful life. DDB does not explicitly use the asset's residual value in the calculations, but depreciation ends once the estimated residual value has been reached. If the asset is expected to have no residual value, the DB method will never fully depreciate it, so the DB method is typically changed to straight-line at some point in the asset's life.
-
-- Param - t - length of the useful life
-
-Examples:
-
-```ruby
-Finrb::Accounting.ddb(cost=1200,rv=200,t=5)
-```
-
-### Debt ratio - Solvency ratios measure the firm's ability to satisfy its long-term obligations
-
-- Param - td - total debt
-
-- Param - ta - total assets
-
-Examples:
-
-```ruby
-Finrb::Ratios.debt_ratio(td=6000,ta=20000)
-```
-
-### Diluted Earnings Per Share
-
-- Param - ni - net income
-
-- Param - pd - preferred dividends
-
-- Param - cpd - dividends on convertible preferred stock
-
-- Param - cdi - interest on convertible debt
-
-- Param - tax - tax rate
-
-- Param - w - weighted average number of common shares outstanding
-
-- Param - cps - shares from conversion of convertible preferred stock
-
-- Param - cds - shares from conversion of convertible debt
-
-- Param - iss - shares issuable from stock options
-
-Examples:
-
-```ruby
-Finrb::Ratios.diluted_eps(ni=115600,pd=10000,cdi=42000,tax=0.4,w=200000,cds=60000)
-```
-
-```ruby
-Finrb::Ratios.diluted_eps(ni=115600,pd=10000,cpd=10000,w=200000,cps=40000)
-```
-
-```ruby
-Finrb::Ratios.diluted_eps(ni=115600,pd=10000,w=200000,iss=2500)
-```
-
-```ruby
-Finrb::Ratios.diluted_eps(ni=115600,pd=10000,cpd=10000,cdi=42000,tax=0.4,w=200000,cps=40000,cds=60000,iss=2500)
-```
-
-### Computing the rate of return for each period
-
-- Param - n - number of periods
-
-- Param - pv - present value
-
-- Param - fv - future value
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-- Param - lower - the lower end points of the rate of return to be searched.
-
-- Param - upper - the upper end points of the rate of return to be searched.
-  @importFrom stats uniroot
-
-Examples:
-
-```ruby
-Finrb::TVM.discount_rate(n=5,pv=0,fv=600,pmt=-100,type=0)
-```
-
-### Convert stated annual rate to the effective annual rate
-
-- Param - r - stated annual rate
-
-- Param - m - number of compounding periods per year
-
-Examples:
-
-```ruby
-Finrb::Yields.ear(r=0.12,m=12)
-```
-
-```ruby
-Finrb::Yields.ear(0.04,365)
-```
-
-### Convert stated annual rate to the effective annual rate with continuous compounding
-
-- Param - r - stated annual rate
-
-Examples:
-
-```ruby
-Finrb::Yields.ear_continuous(r=0.1)
-```
-
-```ruby
-Finrb::Yields.ear_continuous(0.03)
-```
-
-### Bond-equivalent yield (BEY), 2 x the semiannual discount rate
-
-- Param - ear - effective annual rate
-
-Examples:
-
-```ruby
-Finrb::Yields.ear2bey(ear=0.08)
-```
-
-### Computing HPR, the holding period return
-
-- Param - ear - effective annual rate
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.ear2hpr(ear=0.05039,t=150)
-```
-
-### Equivalent/proportional Interest Rates
-
-@description An interest rate to be applied n times p.a. can be converted to an equivalent rate to be applied p times p.a.
-
-- Param - r - interest rate to be applied n times per year (r is annual rate!)
-
-- Param - n - times that the interest rate r were compounded per year
-
-- Param - p - times that the equivalent rate were compounded per year
-
-- Param - type - equivalent interest rates ('e',default) or proportional interest rates ('p')
-
-Examples:
-
-- monthly interest rat equivalent to 5% compounded per year
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=1,p=12)
-```
-
-- monthly interest rat equivalent to 5% compounded per half year
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=2,p=12)
-```
-
-- monthly interest rat equivalent to 5% compounded per quarter
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=4,p=12)
-```
-
-- annual interest rate equivalent to 5% compounded per month
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=12,p=1)
-```
-
-- this is equivalent to
-  ear(r=0.05,m=12)
-
-- quarter interest rate equivalent to 5% compounded per year
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=1,p=4)
-```
-
-- quarter interest rate equivalent to 5% compounded per month
-
-```ruby
-Finrb::Yields.eir(r=0.05,n=12,p=4)
-```
-
-- monthly proportional interest rate which is equivalent to a simple annual interest
-
-```ruby
-Finrb::Yields.eir(r=0.05,p=12,type='p')
-```
-
-### Basic Earnings Per Share
-
-- Param - ni - net income
-
-- Param - pd - preferred dividends
-
-- Param - w - weighted average number of common shares outstanding
-
-Examples:
-
-```ruby
-Finrb::Ratios.eps(ni=10000,pd=1000,w=11000)
-```
-
-### Financial leverage - Solvency ratios measure the firm's ability to satisfy its long-term obligations
-
-- Param - te - total equity
-
-- Param - ta - total assets
-
-Examples:
-
-```ruby
-Finrb::Ratios.financial_leverage(te=16000,ta=20000)
-```
-
-### Estimate future value (fv)
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - pv - present value
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.fv(r=0.07,n=10,pv=1000,pmt=10)
-```
-
-### Estimate future value of an annuity
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.fv_annuity(0.03,12,-1000)
-```
-
-```ruby
-Finrb::TVM.fv_annuity(r=0.03,n=12,pmt=-1000,type=1)
-```
-
-### Estimate future value (fv) of a single sum
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - pv - present value
-
-Examples:
-
-```ruby
-Finrb::TVM.fv_simple(0.08,10,-300)
-```
-
-```ruby
-Finrb::TVM.fv_simple(r=0.04,n=20,pv=-50000)
-```
-
-### Computing the future value of an uneven cash flow series
-
-- Param - r - stated annual rate
-
-- Param - cf - uneven cash flow
-
-Examples:
-
-```ruby
-Finrb::TVM.fv_uneven(r=0.1, cf=[-1000, -500, 0, 4000, 3500, 2000])
-```
-
-### Compound annual growth rate
-
-CAGR expresses the constant annual rate that compounds a beginning value into
-an ending value over a positive integer number of equal annual periods.
-
-```ruby
-Finrb::Returns.cagr(
-  beginning_value: 10_000,
-  ending_value: 16_105.10,
-  periods: 5
+rate = Finrb::Rate.new(0.06, :apr, duration: 12)
+loan = Finrb::Amortization.new(
+  100_000,
+  rate,
+  balloon: 20_000,
+  interest_only_periods: 2,
+  origination_fee: 2_000,
+  finance_origination_fee: true
 )
-# => Flt::DecNum('0.1')
+
+raise unless loan.principal == Flt::DecNum('100000')
+raise unless loan.net_proceeds == Flt::DecNum('100000')
+raise unless loan.amount_financed == Flt::DecNum('102000')
+raise unless loan.schedule.first.interest_only?
+raise unless loan.schedule.sum(&:principal) == loan.amount_financed
 ```
 
-The beginning value must be positive and the ending value cannot be negative.
-An ending value of zero returns `-1`, representing a total loss.
+A block can modify the scheduled payment template, commonly for a constant
+extra payment. It is not yet a general period-indexed prepayment strategy.
 
-### Risk and annualization helpers
+```ruby
+Finrb::Amortization.new(250_000, rate) { |payment| payment.amount - 150 }
+```
 
-`volatility` uses sample standard deviation by default; pass `sample: false`
-for population volatility. Downside deviation is the root mean square of
-shortfalls below the target and includes every observation in its denominator.
+## Time value of money
 
+`Finrb::TVM` provides periodic calculations:
+
+| Method | Purpose |
+| --- | --- |
+| `discount_rate` | Solve a periodic rate from PV, FV, payment, and periods |
+| `fv`, `pv` | Combined lump-sum and annuity value |
+| `fv_annuity`, `pv_annuity` | Annuity value |
+| `fv_simple`, `pv_simple` | Single-sum value |
+| `fv_uneven`, `pv_uneven` | Uneven periodic cashflows |
+| `n_period` | Number of periods |
+| `npv` | Net present value |
+| `pmt` | Periodic payment |
+| `pv_perpetuity`, `r_perpetuity` | Perpetuity value or rate |
+
+`type: 0` means end-of-period payments and `type: 1` means beginning-of-period
+payments.
+
+<!-- verify-example -->
+```ruby
+future = Finrb::TVM.fv(r: 0.05, n: 10, pv: -1000, pmt: 0)
+present = Finrb::TVM.pv(r: 0.05, n: 10, fv: -future, pmt: 0)
+
+raise unless present.round(10) == Flt::DecNum('1000')
+```
+
+## Investment returns and risk
+
+| Method | Convention |
+| --- | --- |
+| `cagr` | Compound growth over a positive integer number of periods |
+| `geometric_mean`, `harmonic_mean` | Multi-period return or average price |
+| `hpr`, `twrr`, `wpr` | Holding-period, time-weighted, or weighted portfolio return |
+| `volatility` | Sample standard deviation by default; `sample: false` selects population |
+| `downside_deviation` | Root-mean-square shortfall using every observation in the denominator |
+| `sortino_ratio` | Mean excess return divided by downside deviation |
+| `max_drawdown` | Largest peak-to-trough loss as a non-negative fraction |
+| `annualize_return` | Compound periodic return |
+| `annualize_volatility` | Square-root-of-time scaling |
+| `sharpe_ratio`, `sf_ratio` | Supplied-return risk ratios |
+
+<!-- verify-example -->
 ```ruby
 returns = [-0.10, 0.05, -0.05]
 
-Finrb::Returns.volatility(returns: returns)
-Finrb::Returns.downside_deviation(returns: returns, target: 0)
-Finrb::Returns.sortino_ratio(returns: returns, target: 0)
-Finrb::Returns.sortino_ratio(returns: returns, target: 0, periods_per_year: 12)
+raise unless Finrb::Returns.cagr(beginning_value: 100, ending_value: 121, periods: 2).round(6) == Flt::DecNum('0.1')
+raise unless Finrb::Returns.volatility(returns: returns).positive?
+raise unless Finrb::Returns.downside_deviation(returns: returns).positive?
+raise unless Finrb::Returns.max_drawdown(values: [100, 120, 90, 150, 105]) == Flt::DecNum('0.3')
 ```
 
-Annual returns compound, while volatility uses square-root-of-time scaling:
+## Yields
 
+`Finrb::Yields` contains money-market and annualized-yield conversions:
+
+- `bdy`, `bdy2mmy`;
+- `ear`, `ear_continuous`, `ear2bey`, `ear2hpr`;
+- `eir`;
+- `hpr2bey`, `hpr2ear`, `hpr2mmy`, `mmy2hpr`;
+- `r_continuous`, `r_norminal`.
+
+The historical public method name `r_norminal` is intentionally retained.
+
+<!-- verify-example -->
 ```ruby
-Finrb::Returns.annualize_return(rate: 0.01, periods_per_year: 12)
-Finrb::Returns.annualize_volatility(volatility: 0.02, periods_per_year: 252)
+yield_rate = Finrb::Yields.ear(r: 0.12, m: 12)
+raise unless yield_rate.round(6) == Flt::DecNum('0.126825')
 ```
 
-Maximum drawdown accepts positive portfolio values and returns the largest
-peak-to-trough loss as a non-negative fraction:
+## Ratios and accounting
 
-```ruby
-Finrb::Returns.max_drawdown(values: [100, 120, 90, 150, 105])
-# => Flt::DecNum('0.3')
+`Finrb::Ratios` provides liquidity, leverage, profitability, earnings, and
+share-count calculations:
+
+```text
+cash_ratio, current_ratio, quick_ratio, debt_ratio, financial_leverage,
+lt_d2e, total_d2e, gpm, npm, eps, diluted_eps, iss, was
 ```
 
-### Geometric mean return
+`Finrb::Accounting` provides inventory costing and depreciation:
 
-- Param - r - returns over multiple periods
+- `cogs` using `FIFO`, `LIFO`, or weighted-average (`WAC`) inventory;
+- `ddb` for double-declining-balance depreciation;
+- `slde` for straight-line depreciation.
 
-Examples:
-
+<!-- verify-example -->
 ```ruby
-Finrb::Returns.geometric_mean(r=[-0.0934, 0.2345, 0.0892])
+ratio = Finrb::Ratios.current_ratio(ca: 8000, cl: 2000)
+inventory = Finrb::Accounting.cogs(
+  uinv: 2,
+  pinv: 2,
+  units: [3, 5],
+  price: [3, 5],
+  sinv: 7,
+  method: 'FIFO'
+)
+
+raise unless ratio == Flt::DecNum('4')
+raise unless inventory.key?(:cost_of_goods)
+raise unless inventory.key?(:ending_inventory)
 ```
 
-### Gross profit margin - Evaluate a company's financial performance
+## Configuration, precision, and errors
 
-- Param - gp - gross profit, equal to revenue minus cost of goods sold (cogs)
-
-- Param - rv - revenue (sales)
-
-Examples:
+`Finrb.config` returns an immutable snapshot. Use `Finrb.configure` at startup
+or `Finrb.with_config` for a temporary execution-local override.
 
 ```ruby
-Finrb::Ratios.gpm(gp=1000,rv=20000)
+Finrb.configure { |config| config.eps = '1e-14' }
+Finrb.with_config(guess: 0.25) { Finrb::Cashflow.irr([-100, 230, -132]) }
 ```
 
-### Harmonic mean, average price
+General calculations retain decimal precision until callers round for display.
+Amortization postings use `Finrb::Precision.money`: two decimal places with
+half-up rounding and final-payment reconciliation.
 
-- Param - p - price over multiple periods
+Public failures use:
 
-Examples:
+- `Finrb::InvalidCashflowError` for malformed cashflows;
+- `Finrb::DomainError` for illegal financial/numerical domains;
+- `Finrb::ConvergenceError` when a root cannot be bracketed or solved;
+- `ArgumentError` for invalid public arguments and options.
 
+## Opt-in core extensions
+
+Loading `finrb` does not modify Ruby core classes. Legacy fluent calls require
+an explicit load:
+
+<!-- verify-example -->
 ```ruby
-Finrb::Returns.harmonic_mean(p=[8,9,10])
-```
-
-### Computing HPR, the holding period return
-
-- Param - ev - ending value
-
-- Param - bv - beginning value
-
-- Param - cfr - cash flow received
-
-Examples:
-
-```ruby
-Finrb::Returns.hpr(ev=33,bv=30,cfr=0.5)
-```
-
-### Bond-equivalent yield (BEY), 2 x the semiannual discount rate
-
-- Param - hpr - holding period return
-
-- Param - t - number of month remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.hpr2bey(hpr=0.02,t=3)
-```
-
-### Convert holding period return to the effective annual rate
-
-- Param - hpr - holding period return
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.hpr2ear(hpr=0.015228,t=120)
-```
-
-### Computing money market yield (MMY) for a T-bill
-
-- Param - hpr - holding period return
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.hpr2mmy(hpr=0.01523,t=120)
-```
-
-### Calculate the net increase in common shares from the potential exercise of stock options or warrants
-
-- Param - amp - average market price over the year
-
-- Param - ep - exercise price of the options or warrants
-
-- Param - n - number of common shares that the options and warrants can be convened into
-
-Examples:
-
-```ruby
-Finrb::Ratios.iss(amp=20,ep=15,n=10000)
-```
-
-### Long-term debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations
-
-- Param - ltd - long-term debt
-
-- Param - te - total equity
-
-Examples:
-
-```ruby
-Finrb::Ratios.lt_d2e(ltd=8000,te=20000)
-```
-
-### Computing HPR, the holding period return
-
-- Param - mmy - money market yield
-
-- Param - t - number of days remaining until maturity
-
-Examples:
-
-```ruby
-Finrb::Yields.mmy2hpr(mmy=0.04898,t=150)
-```
-
-### Estimate the number of periods
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - pv - present value
-
-- Param - fv - future value
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.n_period(0.1,-10000,60000000,-50000,0)
-```
-
-```ruby
-Finrb::TVM.n_period(r=0.1,pv=-10000,fv=60000000,pmt=-50000,type=1)
-```
-
-### Net profit margin - Evaluate a company's financial performance
-
-- Param - ni - net income
-
-- Param - rv - revenue (sales)
-
-Examples:
-
-```ruby
-Finrb::Ratios.npm(ni=8000,rv=20000)
-```
-
-### Computing NPV, the PV of the cash flows less the initial (time = 0) outlay
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - cf - cash flow,the first cash flow is the initial outlay
-
-Examples:
-
-```ruby
-Finrb::TVM.npv(r=0.12, cf=[-5, 1.6, 2.4, 2.8])
-```
-
-### Estimate period payment
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - pv - present value
-
-- Param - fv - future value
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.pmt(0.08,10,-1000,10)
-```
-
-```ruby
-Finrb::TVM.pmt(r=0.08,n=10,pv=-1000,fv=0)
-```
-
-```ruby
-Finrb::TVM.pmt(0.08,10,-1000,10,1)
-```
-
-### Estimate present value (pv)
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - fv - future value
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.pv(0.07,10,1000,10)
-```
-
-```ruby
-Finrb::TVM.pv(r=0.05,n=20,fv=1000,pmt=10,type=1)
-```
-
-### Estimate present value (pv) of an annuity
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.pv_annuity(0.03,12,1000)
-```
-
-```ruby
-Finrb::TVM.pv_annuity(r=0.0425,n=3,pmt=30000)
-```
-
-### Estimate present value of a perpetuity
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - g - growth rate of perpetuity
-
-- Param - pmt - payment per period
-
-- Param - type - payments occur at the end of each period (type=0); payments occur at the beginning of each period (type=1)
-
-Examples:
-
-```ruby
-Finrb::TVM.pv_perpetuity(r=0.1,pmt=1000,g=0.02)
-```
-
-```ruby
-Finrb::TVM.pv_perpetuity(r=0.1,pmt=1000,type=1)
-```
-
-```ruby
-Finrb::TVM.pv_perpetuity(r=0.1,pmt=1000)
-```
-
-### Estimate present value (pv) of a single sum
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - n - number of periods
-
-- Param - fv - future value
-
-Examples:
-
-```ruby
-Finrb::TVM.pv_simple(0.07,10,100)
-```
-
-```ruby
-Finrb::TVM.pv_simple(r=0.03,n=3,fv=1000)
-```
-
-### Computing the present value of an uneven cash flow series
-
-- Param - r - discount rate, or the interest rate at which the amount will be compounded each period
-
-- Param - cf - uneven cash flow
-
-Examples:
-
-```ruby
-Finrb::TVM.pv_uneven(r=0.1, cf=[-1000, -500, 0, 4000, 3500, 2000])
-```
-
-### Quick ratio - Liquidity ratios measure the firm's ability to satisfy its short-term obligations as they come due
-
-- Param - cash - cash
-
-- Param - ms - marketable securities
-
-- Param - rc - receivables
-
-- Param - cl - current liabilities
-
-Examples:
-
-```ruby
-Finrb::Ratios.quick_ratio(cash=3000,ms=2000,rc=1000,cl=2000)
-```
-
-### Convert a given norminal rate to a continuous compounded rate
-
-- Param - r - norminal rate
-
-- Param - m - number of times compounded each year
-
-Examples:
-
-```ruby
-Finrb::Yields.r_continuous(r=0.03,m=4)
-```
-
-### Convert a given continuous compounded rate to a norminal rate
-
-- Param - rc - continuous compounded rate
-
-- Param - m - number of desired times compounded each year
-
-Examples:
-
-```ruby
-Finrb::Yields.r_norminal(0.03,1)
-```
-
-```ruby
-Finrb::Yields.r_norminal(rc=0.03,m=4)
-```
-
-### Rate of return for a perpetuity
-
-- Param - pmt - payment per period
-
-- Param - pv - present value
-
-Examples:
-
-```ruby
-Finrb::TVM.r_perpetuity(pmt=4.5,pv=-75)
-```
-
-### Computing Sampling error
-
-- Param - sm - sample mean
-
-- Param - mu - population mean
-
-Examples:
-
-```ruby
-Finrb::Returns.sampling_error(sm=0.45, mu=0.5)
-```
-
-### Computing Roy's safety-first ratio
-
-- Param - rp - portfolio return
-
-- Param - rl - threshold level return
-
-- Param - sd - standard deviation of portfolio retwns
-
-Examples:
-
-```ruby
-Finrb::Returns.sf_ratio(rp=0.09,rl=0.03,sd=0.12)
-```
-
-### Computing Sharpe Ratio
-
-- Param - rp - portfolio return
-
-- Param - rf - risk-free return
-
-- Param - sd - standard deviation of portfolio retwns
-
-Examples:
-
-```ruby
-Finrb::Returns.sharpe_ratio(rp=0.038,rf=0.015,sd=0.07)
-```
-
-### Depreciation Expense Recognition - Straight-line depreciation (SL) allocates an equal amount of depreciation each year over the asset's useful life
-
-- Param - cost - cost of long-lived assets
-
-- Param - rv - residual value of the long-lived assets at the end of its useful life
-
-- Param - t - length of the useful life
-
-Examples:
-
-```ruby
-Finrb::Accounting.slde(cost=1200,rv=200,t=5)
-```
-
-### Total debt-to-equity - Solvency ratios measure the firm's ability to satisfy its long-term obligations
-
-- Param - td - total debt
-
-- Param - te - total equity
-
-Examples:
-
-```ruby
-Finrb::Ratios.total_d2e(td=6000,te=20000)
-```
-
-### Computing TWRR, the time-weighted rate of return
-
-- Param - ev - ordered ending value list
-
-- Param - bv - ordered beginning value list
-
-- Param - cfr - ordered cash flow received list
-
-Examples:
-
-```ruby
-Finrb::Returns.twrr(ev=[120,260],bv=[100,240],cfr=[2,4])
-```
-
-### Calculate weighted average shares - weighted average number of common shares
-
-- Param - ns - n x 1 vector vector of number of shares
-
-- Param - nm - n x 1 vector vector of number of months relate to ns
-
-Examples:
-
-s=[10000,2000];m=[12,6];
-
-```ruby
-Finrb::Ratios.was(ns=s,nm=m)
-```
-
-s=[11000,4400,-3000];m=[12,9,4];
-
-```ruby
-Finrb::Ratios.was(ns=s,nm=m)
-```
-
-### Weighted mean as a portfolio return
-
-- Param - r - returns of the individual assets in the portfolio
-
-- Param - w - corresponding weights associated with each of the individual assets
-
-Examples:
-
-```ruby
-Finrb::Returns.wpr(r=[0.12, 0.07, 0.03],w=[0.5,0.4,0.1])
+require 'finrb/core_ext'
+
+raise unless [-4000, 1200, 1410, 1875, 1050].irr.round(3) == Flt::DecNum('0.143')
+rate = Finrb::Rate.new(0.05, :apr, duration: 12)
+raise unless 10_000.amortize(rate).balance.zero?
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,6 +156,11 @@ Finrb::Amortization.new(250_000, rate) { |payment| payment.amount - 150 }
 `type: 0` means end-of-period payments and `type: 1` means beginning-of-period
 payments.
 
+Zero-rate annuities and payments use their linear mathematical limits. Other
+periodic TVM rates may be negative but must remain greater than `-1`.
+`discount_rate` searches that full domain around `guess:`; callers may instead
+supply both `lower:` and `upper:` as an explicit sign-changing bracket.
+
 <!-- verify-example -->
 ```ruby
 future = Finrb::TVM.fv(r: 0.05, n: 10, pv: -1000, pmt: 0)

--- a/finrb.gemspec
+++ b/finrb.gemspec
@@ -42,7 +42,7 @@ SPEC =
     s.add_development_dependency('semver')
     s.add_development_dependency('simplecov')
 
-    s.files = Dir['CHANGELOG.md', 'COPYING*', 'NOTICE.md', 'README.md', 'lib/**/*', 'sig/**/*'].sort
+    s.files = Dir['CHANGELOG.md', 'CONTRIBUTING.md', 'COPYING*', 'NOTICE.md', 'README.md', 'SECURITY.md', 'lib/**/*', 'sig/**/*'].sort
     s.require_paths = ['lib']
 
     s.extra_rdoc_files = ['README.md', 'CHANGELOG.md', 'NOTICE.md', 'COPYING', 'COPYING.LESSER']

--- a/finrb.gemspec
+++ b/finrb.gemspec
@@ -28,6 +28,7 @@ SPEC =
     s.add_dependency('ostruct')
 
     s.add_development_dependency('amazing_print')
+    s.add_development_dependency('benchmark-ips')
     s.add_development_dependency('bundler-audit')
     s.add_development_dependency('pry')
     s.add_development_dependency('rake')

--- a/lib/finrb/accounting.rb
+++ b/lib/finrb/accounting.rb
@@ -2,6 +2,7 @@
 
 require_relative 'decimal'
 require_relative 'errors'
+require_relative 'validation'
 
 module Finrb
   # Inventory costing and depreciation calculations.
@@ -34,74 +35,32 @@ module Finrb
     # @example
     #   Finrb::Accounting.cogs(uinv=2,pinv=2,units=[3,5],price=[3,5],sinv=7,method="WAC")
     def self.cogs(uinv:, pinv:, units:, price:, sinv:, method: 'FIFO')
-      uinv = Flt::DecNum(uinv.to_s)
-      pinv = Flt::DecNum(pinv.to_s)
-      units = wrap_array(units).map { |value| Flt::DecNum(value.to_s) }
-      price = wrap_array(price).map { |value| Flt::DecNum(value.to_s) }
-      sinv = Flt::DecNum(sinv.to_s)
-      method = method.to_s
+      uinv, pinv, units, price, sinv, method = inventory_inputs(uinv:, pinv:, units:, price:, sinv:, method:)
 
       n = units.size
-      m = price.size
-      cost_of_goods = 0
-      ending_inventory = 0
-      if m == n
-        case method
-        when 'FIFO'
-          if sinv <= uinv
-            cost_of_goods = sinv * pinv
-            ending_inventory = (uinv - sinv) * pinv
-            (0...n).each do |i|
-              ending_inventory += (units[i] * price[i])
-            end
-          else
-            cost_of_goods = uinv * pinv
-            sinv -= uinv
-            (0...n).each do |i|
-              if sinv <= units[i]
-                cost_of_goods += (sinv * price[i])
-                ending_inventory = (units[i] - sinv) * price[i]
-                if i < n
-                  temp = i + 1
-                  (temp...n).each do |j|
-                    ending_inventory += (units[j] * price[j])
-                  end
-                end
-                sinv = 0
-                break
-              else
-                cost_of_goods += (units[i] * price[i])
-                sinv -= units[i]
-              end
-            end
-            raise(Error, "Inventory is not enough to sell\n") if sinv.positive?
-          end
-        when 'WAC'
-          ending_inventory = uinv * pinv
-          tu = uinv
+      cost_of_goods = Flt::DecNum(0)
+      ending_inventory = Flt::DecNum(0)
+      case method
+      when 'FIFO'
+        if sinv <= uinv
+          cost_of_goods = sinv * pinv
+          ending_inventory = (uinv - sinv) * pinv
           (0...n).each do |i|
             ending_inventory += (units[i] * price[i])
-            tu += units[i]
           end
-          if tu >= sinv
-            cost_of_goods = ending_inventory / tu * sinv
-            ending_inventory = ending_inventory / tu * (tu - sinv)
-          else
-            raise(Error, "Inventory is not enough to sell\n")
-          end
-
-        when 'LIFO'
-          (n - 1).downto(0).each do |i|
+        else
+          cost_of_goods = uinv * pinv
+          sinv -= uinv
+          (0...n).each do |i|
             if sinv <= units[i]
               cost_of_goods += (sinv * price[i])
               ending_inventory = (units[i] - sinv) * price[i]
-              if i > 1
-                temp = i - 1
-                temp.downto(0).each do |j|
+              if i < n
+                temp = i + 1
+                (temp...n).each do |j|
                   ending_inventory += (units[j] * price[j])
                 end
               end
-              ending_inventory += (uinv * pinv)
               sinv = 0
               break
             else
@@ -109,18 +68,52 @@ module Finrb
               sinv -= units[i]
             end
           end
-          if sinv.positive?
-            if sinv <= uinv
-              cost_of_goods += (sinv * pinv)
-              ending_inventory += ((uinv - sinv) * pinv)
-            else
-              raise(Error, "Inventory is not enough to sell\n")
-            end
-          end
+          raise(DomainError, 'Available inventory is insufficient for the requested sale.') if sinv.positive?
+        end
+      when 'WAC'
+        ending_inventory = uinv * pinv
+        tu = uinv
+        (0...n).each do |i|
+          ending_inventory += (units[i] * price[i])
+          tu += units[i]
+        end
+        if tu.zero? && sinv.zero?
+          cost_of_goods = Flt::DecNum(0)
+          ending_inventory = Flt::DecNum(0)
+        elsif tu >= sinv
+          cost_of_goods = ending_inventory / tu * sinv
+          ending_inventory = ending_inventory / tu * (tu - sinv)
+        else
+          raise(DomainError, 'Available inventory is insufficient for the requested sale.')
         end
 
-      else
-        raise(Error, "length of units and price are not the same\n")
+      when 'LIFO'
+        (n - 1).downto(0).each do |i|
+          if sinv <= units[i]
+            cost_of_goods += (sinv * price[i])
+            ending_inventory = (units[i] - sinv) * price[i]
+            if i.positive?
+              temp = i - 1
+              temp.downto(0).each do |j|
+                ending_inventory += (units[j] * price[j])
+              end
+            end
+            ending_inventory += (uinv * pinv)
+            sinv = 0
+            break
+          else
+            cost_of_goods += (units[i] * price[i])
+            sinv -= units[i]
+          end
+        end
+        if sinv.positive?
+          if sinv <= uinv
+            cost_of_goods += (sinv * pinv)
+            ending_inventory += ((uinv - sinv) * pinv)
+          else
+            raise(DomainError, 'Available inventory is insufficient for the requested sale.')
+          end
+        end
       end
 
       {
@@ -128,6 +121,20 @@ module Finrb
         ending_inventory:
       }
     end
+
+    def self.inventory_inputs(uinv:, pinv:, units:, price:, sinv:, method:)
+      uinv = Validation.non_negative_decimal(uinv, name: 'beginning inventory units')
+      pinv = Validation.non_negative_decimal(pinv, name: 'beginning inventory unit cost')
+      units = inventory_values(units, name: 'purchase units')
+      price = inventory_values(price, name: 'purchase unit cost')
+      sinv = Validation.non_negative_decimal(sinv, name: 'units sold')
+      method = method.to_s
+      raise(ArgumentError, 'Inventory costing method must be FIFO, LIFO, or WAC.') unless %w[FIFO LIFO WAC].include?(method)
+      raise(ArgumentError, 'Purchase units and unit costs must have equal lengths.') unless units.size == price.size
+
+      [uinv, pinv, units, price, sinv, method]
+    end
+    private_class_method :inventory_inputs
 
     # Depreciation Expense Recognition -- double-declining balance (DDB), the most common declining balance method, which applies two times the straight-line rate to the declining balance.
     #
@@ -137,11 +144,10 @@ module Finrb
     # @example
     #   Finrb::Accounting.ddb(cost=1200,rv=200,t=5)
     def self.ddb(cost:, rv:, t:)
-      cost = Flt::DecNum(cost.to_s)
-      rv = Flt::DecNum(rv.to_s)
-      t = Flt::DecNum(t.to_s)
-
-      raise(Error, 't should be larger than 1') if t < 2
+      cost = Validation.non_negative_decimal(cost, name: 'asset cost')
+      rv = residual_value(rv, cost:)
+      t = Validation.positive_integer(t, name: 'useful life')
+      raise(DomainError, 'Useful life must be at least 2 periods for double-declining depreciation.') if t < 2
 
       ddb = [Flt::DecNum(0)] * t
       ddb[0] = cost * 2 / t
@@ -170,11 +176,24 @@ module Finrb
     # @example
     #   Finrb::Accounting.slde(cost=1200,rv=200,t=5)
     def self.slde(cost:, rv:, t:)
-      cost = Flt::DecNum(cost.to_s)
-      rv = Flt::DecNum(rv.to_s)
-      t = Flt::DecNum(t.to_s)
+      cost = Validation.non_negative_decimal(cost, name: 'asset cost')
+      rv = residual_value(rv, cost:)
+      t = Validation.positive_decimal(t, name: 'useful life', error: DomainError)
 
       ((cost - rv) / t)
     end
+
+    def self.inventory_values(values, name:)
+      wrap_array(values).map { |value| Validation.non_negative_decimal(value, name:) }
+    end
+    private_class_method :inventory_values
+
+    def self.residual_value(value, cost:)
+      value = Validation.non_negative_decimal(value, name: 'residual value')
+      raise(DomainError, 'Residual value must not exceed asset cost.') if value > cost
+
+      value
+    end
+    private_class_method :residual_value
   end
 end

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -37,7 +37,7 @@ module Finrb
         @interest_only = interest_only
         MONETARY_ATTRIBUTES.each do |name|
           value = binding.local_variable_get(name)
-          instance_variable_set("@#{name}", Validation.decimal(value, name: name.to_s))
+          instance_variable_set("@#{name}", Validation.decimal(value, name: name.to_s.tr('_', ' ')))
         end
         freeze
       end
@@ -98,7 +98,7 @@ module Finrb
 
       rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'periodic rate')
 
-      periods = Validation.positive_integer(periods, name: 'periods')
+      periods = Validation.positive_integer(periods, name: 'period count')
 
       if rate.zero?
         # simplified formula to avoid division-by-zero when interest rate is zero
@@ -117,7 +117,7 @@ module Finrb
     def initialize(principal, *rates, balloon: 0, interest_only_periods: 0, origination_fee: 0, finance_origination_fee: false, &block)
       @principal = Validation.positive_decimal(principal, name: 'principal', message: 'principal must be positive.')
 
-      @origination_fee = Validation.non_negative_decimal(origination_fee, name: 'origination_fee', message: 'origination_fee must be non-negative.')
+      @origination_fee = Validation.non_negative_decimal(origination_fee, name: 'origination fee')
       raise(ArgumentError, 'finance_origination_fee must be true or false.') unless [true, false].include?(finance_origination_fee)
       raise(ArgumentError, 'an unfinanced origination_fee must be less than principal.') if !finance_origination_fee && @origination_fee >= @principal
 

--- a/lib/finrb/amortization.rb
+++ b/lib/finrb/amortization.rb
@@ -91,14 +91,12 @@ module Finrb
     #   Amortization.payment(200000, rate.monthly, rate.duration) #=> Flt::DecNum('-926.23')
     # @see https://en.wikipedia.org/wiki/Amortization_calculator
     def self.payment(principal, rate, periods, balloon: 0)
-      principal = Validation.decimal(principal, name: 'principal')
-      raise(ArgumentError, 'principal must be positive.') unless principal.positive?
+      principal = Validation.positive_decimal(principal, name: 'principal', message: 'principal must be positive.')
 
       balloon = Validation.decimal(balloon, name: 'balloon')
       raise(ArgumentError, 'balloon must be non-negative and no greater than principal.') unless balloon.between?(0, principal)
 
-      rate = Validation.decimal(rate, name: 'rate')
-      raise(ArgumentError, 'periodic rate must be greater than -1.') if rate <= -1
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'periodic rate')
 
       periods = Validation.positive_integer(periods, name: 'periods')
 
@@ -117,11 +115,9 @@ module Finrb
     # @param [Rate] rates the applicable interest rates
     # @param [Proc] block
     def initialize(principal, *rates, balloon: 0, interest_only_periods: 0, origination_fee: 0, finance_origination_fee: false, &block)
-      @principal = Validation.decimal(principal, name: 'principal')
-      raise(ArgumentError, 'principal must be positive.') unless @principal.positive?
+      @principal = Validation.positive_decimal(principal, name: 'principal', message: 'principal must be positive.')
 
-      @origination_fee = Validation.decimal(origination_fee, name: 'origination_fee')
-      raise(ArgumentError, 'origination_fee must be non-negative.') if @origination_fee.negative?
+      @origination_fee = Validation.non_negative_decimal(origination_fee, name: 'origination_fee', message: 'origination_fee must be non-negative.')
       raise(ArgumentError, 'finance_origination_fee must be true or false.') unless [true, false].include?(finance_origination_fee)
       raise(ArgumentError, 'an unfinanced origination_fee must be less than principal.') if !finance_origination_fee && @origination_fee >= @principal
 

--- a/lib/finrb/cashflows.rb
+++ b/lib/finrb/cashflows.rb
@@ -77,8 +77,7 @@ module Finrb
       validate_numeric_cashflows!
       cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
 
-      rate = Validation.decimal(rate, name: 'rate')
-      raise(DomainError, 'Rate must be greater than -1.') if rate <= -1
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'Rate', error: DomainError)
 
       total = Flt::DecNum.new(0.to_s)
       cashflows.each_with_index do |cashflow, index|
@@ -98,9 +97,8 @@ module Finrb
       cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
       raise(InvalidCashflowError, 'Cashflow needs at least one positive and one negative value.') if cashflows.none?(&:positive?) || cashflows.none?(&:negative?)
 
-      finance_rate = Validation.decimal(finance_rate, name: 'finance_rate')
-      reinvestment_rate = Validation.decimal(reinvestment_rate, name: 'reinvestment_rate')
-      raise(DomainError, 'Finance and reinvestment rates must be greater than -1.') if finance_rate <= -1 || reinvestment_rate <= -1
+      finance_rate = Validation.decimal_greater_than(finance_rate, minimum: -1, name: 'finance_rate', error: DomainError)
+      reinvestment_rate = Validation.decimal_greater_than(reinvestment_rate, minimum: -1, name: 'reinvestment_rate', error: DomainError)
 
       last_period = cashflows.size - 1
       future_positive =
@@ -156,8 +154,7 @@ module Finrb
     #   Finrb::Cashflow.xnpv(@transactions, 0.6).round(2) #=> -937.41
     def xnpv(rate)
       validate_dated_cashflows!
-      rate = Validation.decimal(rate, name: 'rate')
-      raise(DomainError, 'Rate must be greater than -1.') if rate <= -1
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'Rate', error: DomainError)
 
       sum do |t|
         t.amount / ((rate + 1)**(date_diff(start, t.date) / days_in_period))

--- a/lib/finrb/cashflows.rb
+++ b/lib/finrb/cashflows.rb
@@ -77,7 +77,7 @@ module Finrb
       validate_numeric_cashflows!
       cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
 
-      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'Rate', error: DomainError)
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'rate', error: DomainError)
 
       total = Flt::DecNum.new(0.to_s)
       cashflows.each_with_index do |cashflow, index|
@@ -97,8 +97,8 @@ module Finrb
       cashflows = map { |entry| Validation.decimal(entry, name: 'cashflow amount') }
       raise(InvalidCashflowError, 'Cashflow needs at least one positive and one negative value.') if cashflows.none?(&:positive?) || cashflows.none?(&:negative?)
 
-      finance_rate = Validation.decimal_greater_than(finance_rate, minimum: -1, name: 'finance_rate', error: DomainError)
-      reinvestment_rate = Validation.decimal_greater_than(reinvestment_rate, minimum: -1, name: 'reinvestment_rate', error: DomainError)
+      finance_rate = Validation.decimal_greater_than(finance_rate, minimum: -1, name: 'finance rate', error: DomainError)
+      reinvestment_rate = Validation.decimal_greater_than(reinvestment_rate, minimum: -1, name: 'reinvestment rate', error: DomainError)
 
       last_period = cashflows.size - 1
       future_positive =
@@ -154,7 +154,7 @@ module Finrb
     #   Finrb::Cashflow.xnpv(@transactions, 0.6).round(2) #=> -937.41
     def xnpv(rate)
       validate_dated_cashflows!
-      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'Rate', error: DomainError)
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'rate', error: DomainError)
 
       sum do |t|
         t.amount / ((rate + 1)**(date_diff(start, t.date) / days_in_period))

--- a/lib/finrb/config.rb
+++ b/lib/finrb/config.rb
@@ -41,16 +41,16 @@ module Finrb
   end
 
   def self.build_configuration(values)
-    eps = configuration_decimal(values.fetch(:eps), name: 'eps')
-    raise(ArgumentError, 'eps must be positive.') unless eps.positive?
+    eps = configuration_decimal(values.fetch(:eps), name: 'solver tolerance')
+    raise(ArgumentError, 'solver tolerance must be positive.') unless eps.positive?
 
-    guess = configuration_decimal(values.fetch(:guess), name: 'guess')
-    raise(ArgumentError, 'guess must be greater than -1.') if guess <= -1
+    guess = configuration_decimal(values.fetch(:guess), name: 'rate guess')
+    raise(ArgumentError, 'rate guess must be greater than -1.') if guess <= -1
 
     business_days = values.fetch(:business_days)
     periodic_compound = values.fetch(:periodic_compound)
     booleans = [business_days, periodic_compound].all? { |value| value.equal?(true) || value.equal?(false) }
-    raise(ArgumentError, 'business_days and periodic_compound must be boolean.') unless booleans
+    raise(ArgumentError, 'business days and periodic compounding settings must be boolean.') unless booleans
 
     Configuration.new(eps:, guess:, business_days:, periodic_compound:)
   end

--- a/lib/finrb/rates.rb
+++ b/lib/finrb/rates.rb
@@ -137,7 +137,7 @@ module Finrb
     end
 
     def duration=(value)
-      @duration = Validation.positive_integer(value, name: 'duration')
+      @duration = Validation.positive_integer(value, name: 'duration in months')
     end
 
     # set the effective interest rate

--- a/lib/finrb/rates.rb
+++ b/lib/finrb/rates.rb
@@ -17,10 +17,7 @@ module Finrb
       infinite = value.infinite? if value.respond_to?(:infinite?)
       return Flt::DecNum.infinity if [true, 1].include?(infinite)
 
-      periods = Validation.decimal(value, name: 'compounding periods')
-      raise(ArgumentError, 'compounding periods must be positive.') unless periods.positive?
-
-      periods
+      Validation.positive_decimal(value, name: 'compounding periods', message: 'compounding periods must be positive.')
     end
     private_class_method :compounding_periods
 
@@ -49,8 +46,7 @@ module Finrb
     #   Rate.to_nominal(0.06, 365) #=> Flt::DecNum('0.05827')
     # @see https://www.miniwebtool.com/nominal-interest-rate-calculator/
     def self.to_nominal(rate, periods)
-      rate = Validation.decimal(rate, name: 'rate')
-      raise(ArgumentError, 'effective rate must be greater than -1.') if rate <= -1
+      rate = Validation.decimal_greater_than(rate, minimum: -1, name: 'effective rate')
 
       periods = compounding_periods(periods)
 

--- a/lib/finrb/ratios.rb
+++ b/lib/finrb/ratios.rb
@@ -2,6 +2,7 @@
 
 require_relative 'decimal'
 require_relative 'errors'
+require_relative 'validation'
 
 module Finrb
   # Financial-statement, leverage, and per-share ratios.
@@ -25,9 +26,9 @@ module Finrb
     # @example
     #   Finrb::Ratios.cash_ratio(cash=3000,ms=2000,cl=2000)
     def self.cash_ratio(cash:, ms:, cl:)
-      cash = Flt::DecNum(cash.to_s)
-      ms = Flt::DecNum(ms.to_s)
-      cl = Flt::DecNum(cl.to_s)
+      cash = Validation.decimal(cash, name: 'cash')
+      ms = Validation.decimal(ms, name: 'marketable securities')
+      cl = Validation.non_zero_decimal(cl, name: 'current liabilities', error: DomainError)
 
       ((cash + ms) / cl)
     end
@@ -39,8 +40,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.current_ratio(ca=8000,cl=2000)
     def self.current_ratio(ca:, cl:)
-      ca = Flt::DecNum(ca.to_s)
-      cl = Flt::DecNum(cl.to_s)
+      ca = Validation.decimal(ca, name: 'current assets')
+      cl = Validation.non_zero_decimal(cl, name: 'current liabilities', error: DomainError)
 
       (ca / cl)
     end
@@ -52,8 +53,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.debt_ratio(td=6000,ta=20000)
     def self.debt_ratio(td:, ta:)
-      td = Flt::DecNum(td.to_s)
-      ta = Flt::DecNum(ta.to_s)
+      td = Validation.decimal(td, name: 'total debt')
+      ta = Validation.non_zero_decimal(ta, name: 'total assets', error: DomainError)
 
       (td / ta)
     end
@@ -81,15 +82,15 @@ module Finrb
     # @example
     #   Finrb::Ratios.diluted_eps(ni=115600,pd=10000,cpd=10000,cdi=42000,tax=0.4,w=200000,cps=40000,cds=60000,iss=2500)
     def self.diluted_eps(ni:, pd:, w:, cpd: 0, cdi: 0, tax: 0, cps: 0, cds: 0, iss: 0)
-      ni = Flt::DecNum(ni.to_s)
-      pd = Flt::DecNum(pd.to_s)
-      w = Flt::DecNum(w.to_s)
-      cpd = Flt::DecNum(cpd.to_s)
-      cdi = Flt::DecNum(cdi.to_s)
-      tax = Flt::DecNum(tax.to_s)
-      cps = Flt::DecNum(cps.to_s)
-      cds = Flt::DecNum(cds.to_s)
-      iss = Flt::DecNum(iss.to_s)
+      ni = Validation.decimal(ni, name: 'net income')
+      pd = Validation.decimal(pd, name: 'preferred dividends')
+      w = Validation.positive_decimal(w, name: 'weighted average common shares', error: DomainError)
+      cpd = Validation.non_negative_decimal(cpd, name: 'convertible preferred dividends')
+      cdi = Validation.non_negative_decimal(cdi, name: 'convertible debt interest')
+      tax = Validation.decimal_between(tax, minimum: 0, maximum: 1, name: 'tax rate')
+      cps = Validation.non_negative_decimal(cps, name: 'convertible preferred shares')
+      cds = Validation.non_negative_decimal(cds, name: 'convertible debt shares')
+      iss = Validation.non_negative_decimal(iss, name: 'incremental option shares')
 
       basic = (ni - pd) / w
       diluted = (ni - pd + cpd + (cdi * (1 - tax))) / (w + cps + cds + iss)
@@ -105,9 +106,9 @@ module Finrb
     # @example
     #   Finrb::Ratios.eps(ni=10000,pd=1000,w=11000)
     def self.eps(ni:, pd:, w:)
-      ni = Flt::DecNum(ni.to_s)
-      pd = Flt::DecNum(pd.to_s)
-      w = Flt::DecNum(w.to_s)
+      ni = Validation.decimal(ni, name: 'net income')
+      pd = Validation.decimal(pd, name: 'preferred dividends')
+      w = Validation.positive_decimal(w, name: 'weighted average common shares', error: DomainError)
 
       ((ni - pd) / w)
     end
@@ -119,8 +120,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.financial_leverage(te=16000,ta=20000)
     def self.financial_leverage(te:, ta:)
-      te = Flt::DecNum(te.to_s)
-      ta = Flt::DecNum(ta.to_s)
+      te = Validation.non_zero_decimal(te, name: 'total equity', error: DomainError)
+      ta = Validation.decimal(ta, name: 'total assets')
 
       (ta / te)
     end
@@ -132,8 +133,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.gpm(gp=1000,rv=20000)
     def self.gpm(gp:, rv:)
-      gp = Flt::DecNum(gp.to_s)
-      rv = Flt::DecNum(rv.to_s)
+      gp = Validation.decimal(gp, name: 'gross profit')
+      rv = Validation.non_zero_decimal(rv, name: 'revenue', error: DomainError)
 
       (gp / rv)
     end
@@ -146,14 +147,14 @@ module Finrb
     # @example
     #   Finrb::Ratios.iss(amp=20,ep=15,n=10000)
     def self.iss(amp:, ep:, n:)
-      amp = Flt::DecNum(amp.to_s)
-      ep = Flt::DecNum(ep.to_s)
-      n = Flt::DecNum(n.to_s)
+      amp = Validation.positive_decimal(amp, name: 'average market price', error: DomainError)
+      ep = Validation.non_negative_decimal(ep, name: 'exercise price')
+      n = Validation.non_negative_decimal(n, name: 'option shares')
 
       if amp > ep
         ((amp - ep) * n / amp)
       else
-        raise(Error, 'amp must larger than ep')
+        raise(DomainError, 'Average market price must be greater than exercise price.')
       end
     end
 
@@ -164,8 +165,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.lt_d2e(ltd=8000,te=20000)
     def self.lt_d2e(ltd:, te:)
-      ltd = Flt::DecNum(ltd.to_s)
-      te = Flt::DecNum(te.to_s)
+      ltd = Validation.decimal(ltd, name: 'long-term debt')
+      te = Validation.non_zero_decimal(te, name: 'total equity', error: DomainError)
 
       (ltd / te)
     end
@@ -177,8 +178,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.npm(ni=8000,rv=20000)
     def self.npm(ni:, rv:)
-      ni = Flt::DecNum(ni.to_s)
-      rv = Flt::DecNum(rv.to_s)
+      ni = Validation.decimal(ni, name: 'net income')
+      rv = Validation.non_zero_decimal(rv, name: 'revenue', error: DomainError)
 
       (ni / rv)
     end
@@ -192,10 +193,10 @@ module Finrb
     # @example
     #   Finrb::Ratios.quick_ratio(cash=3000,ms=2000,rc=1000,cl=2000)
     def self.quick_ratio(cash:, ms:, rc:, cl:)
-      cash = Flt::DecNum(cash.to_s)
-      ms = Flt::DecNum(ms.to_s)
-      rc = Flt::DecNum(rc.to_s)
-      cl = Flt::DecNum(cl.to_s)
+      cash = Validation.decimal(cash, name: 'cash')
+      ms = Validation.decimal(ms, name: 'marketable securities')
+      rc = Validation.decimal(rc, name: 'receivables')
+      cl = Validation.non_zero_decimal(cl, name: 'current liabilities', error: DomainError)
 
       ((cash + ms + rc) / cl)
     end
@@ -207,8 +208,8 @@ module Finrb
     # @example
     #   Finrb::Ratios.total_d2e(td=6000,te=20000)
     def self.total_d2e(td:, te:)
-      td = Flt::DecNum(td.to_s)
-      te = Flt::DecNum(te.to_s)
+      td = Validation.decimal(td, name: 'total debt')
+      te = Validation.non_zero_decimal(te, name: 'total equity', error: DomainError)
 
       (td / te)
     end
@@ -223,8 +224,8 @@ module Finrb
     # @example
     #   s=[11000,4400,-3000];m=[12,9,4];Finrb::Ratios.was(ns=s,nm=m)
     def self.was(ns:, nm:)
-      ns = wrap_array(ns).map { |value| Flt::DecNum(value.to_s) }
-      nm = wrap_array(nm).map { |value| Flt::DecNum(value.to_s) }
+      ns = wrap_array(ns).map { |value| Validation.decimal(value, name: 'share change') }
+      nm = wrap_array(nm).map { |value| Validation.decimal_between(value, minimum: 0, maximum: 12, name: 'months outstanding') }
 
       m = ns.size
       n = nm.size
@@ -234,7 +235,7 @@ module Finrb
           sum += (ns[i] * nm[i])
         end
       else
-        raise(Error, 'length of ns and nm must be equal')
+        raise(ArgumentError, 'Share changes and months outstanding must have equal lengths.')
       end
       sum /= 12
       sum

--- a/lib/finrb/returns.rb
+++ b/lib/finrb/returns.rb
@@ -121,8 +121,9 @@ module Finrb
     # @example
     #   Finrb::Returns.coefficient_variation(sd=0.15,avg=0.39)
     def self.coefficient_variation(sd:, avg:)
-      sd = Flt::DecNum(sd.to_s)
-      avg = Flt::DecNum(avg.to_s)
+      sd = Validation.non_negative_decimal(sd, name: 'standard deviation')
+      avg = Validation.decimal(avg, name: 'average')
+      raise(DomainError, 'Average must be non-zero.') if avg.zero?
 
       (sd / avg)
     end
@@ -133,10 +134,13 @@ module Finrb
     # @example
     #   Finrb::Returns.geometric_mean(r=[-0.0934, 0.2345, 0.0892])
     def self.geometric_mean(r:)
-      r = wrap_array(r).map { |value| Flt::DecNum(value.to_s) }
+      returns = risk_values(r, name: 'return')
+      returns.each do |value|
+        raise(DomainError, 'Returns must be greater than or equal to -1.') if value < -1
+      end
 
-      rs = r.map { |value| value + 1 }
-      ((rs.reduce(:*)**(Flt::DecNum(1) / rs.size)) - 1)
+      growth_factors = returns.map { |value| value + 1 }
+      ((growth_factors.reduce(:*)**(Flt::DecNum(1) / growth_factors.size)) - 1)
     end
 
     # harmonic mean, average price
@@ -144,9 +148,10 @@ module Finrb
     # @example
     #   Finrb::Returns.harmonic_mean(p=[8,9,10])
     def self.harmonic_mean(p:)
-      p = wrap_array(p).map { |value| Flt::DecNum(value.to_s) }
+      prices = risk_values(p, name: 'price')
+      raise(DomainError, 'Prices must be greater than zero.') unless prices.all?(&:positive?)
 
-      (Flt::DecNum(1) / (p.sum { |val| Flt::DecNum(1) / val } / p.size))
+      (Flt::DecNum(1) / (prices.sum { |price| Flt::DecNum(1) / price } / prices.size))
     end
 
     # Computing HPR, the holding period return
@@ -157,9 +162,9 @@ module Finrb
     # @example
     #   Finrb::Returns.hpr(ev=33,bv=30,cfr=0.5)
     def self.hpr(ev:, bv:, cfr: 0)
-      ev = Flt::DecNum(ev.to_s)
-      bv = Flt::DecNum(bv.to_s)
-      cfr = Flt::DecNum(cfr.to_s)
+      ev = Validation.decimal(ev, name: 'ending value')
+      bv = Validation.positive_decimal(bv, name: 'beginning value', error: DomainError)
+      cfr = Validation.decimal(cfr, name: 'cashflow received')
 
       ((ev - bv + cfr) / bv)
     end
@@ -171,8 +176,8 @@ module Finrb
     # @example
     #   Finrb::Returns.sampling_error(sm=0.45, mu=0.5)
     def self.sampling_error(sm:, mu:)
-      sm = Flt::DecNum(sm.to_s)
-      mu = Flt::DecNum(mu.to_s)
+      sm = Validation.decimal(sm, name: 'sample mean')
+      mu = Validation.decimal(mu, name: 'population mean')
 
       (sm - mu)
     end
@@ -185,9 +190,9 @@ module Finrb
     # @example
     #   Finrb::Returns.sf_ratio(rp=0.09,rl=0.03,sd=0.12)
     def self.sf_ratio(rp:, rl:, sd:)
-      rp = Flt::DecNum(rp.to_s)
-      rl = Flt::DecNum(rl.to_s)
-      sd = Flt::DecNum(sd.to_s)
+      rp = Validation.decimal(rp, name: 'portfolio return')
+      rl = Validation.decimal(rl, name: 'threshold return')
+      sd = Validation.positive_decimal(sd, name: 'standard deviation', error: DomainError)
 
       ((rp - rl) / sd)
     end
@@ -200,9 +205,9 @@ module Finrb
     # @example
     #   Finrb::Returns.sharpe_ratio(rp=0.038,rf=0.015,sd=0.07)
     def self.sharpe_ratio(rp:, rf:, sd:)
-      rp = Flt::DecNum(rp.to_s)
-      rf = Flt::DecNum(rf.to_s)
-      sd = Flt::DecNum(sd.to_s)
+      rp = Validation.decimal(rp, name: 'portfolio return')
+      rf = Validation.decimal(rf, name: 'risk-free return')
+      sd = Validation.positive_decimal(sd, name: 'standard deviation', error: DomainError)
 
       ((rp - rf) / sd)
     end
@@ -215,22 +220,20 @@ module Finrb
     # @example
     #   Finrb::Returns.twrr(ev=[120,260],bv=[100,240],cfr=[2,4])
     def self.twrr(ev:, bv:, cfr:)
-      ev = wrap_array(ev).map { |value| Flt::DecNum(value.to_s) }
-      bv = wrap_array(bv).map { |value| Flt::DecNum(value.to_s) }
-      cfr = wrap_array(cfr).map { |value| Flt::DecNum(value.to_s) }
+      ending_values = risk_values(ev, name: 'ending value')
+      beginning_values = risk_values(bv, name: 'beginning value')
+      cashflows_received = risk_values(cfr, name: 'cashflow received')
+      sizes = [ending_values.size, beginning_values.size, cashflows_received.size]
+      raise(ArgumentError, 'Ending values, beginning values, and cashflows received must have equal lengths.') unless sizes.uniq.one?
 
-      r = ev.size
-      s = bv.size
-      t = cfr.size
-      wr = Flt::DecNum(1)
-      if r != s || r != t || s != t
-        raise(Error, 'Different number of values!')
-      else
-        (0...r).each do |i|
-          wr *= (Finrb::Returns.hpr(ev: ev[i], bv: bv[i], cfr: cfr[i]) + 1)
+      wealth_relative =
+        ending_values.each_index.reduce(Flt::DecNum(1)) do |product, index|
+          period_growth = hpr(ev: ending_values[index], bv: beginning_values[index], cfr: cashflows_received[index]) + 1
+          raise(DomainError, 'Each subperiod wealth relative must be greater than or equal to zero.') if period_growth.negative?
+
+          product * period_growth
         end
-        ((wr**(Flt::DecNum(1) / r)) - 1)
-      end
+      (wealth_relative**(Flt::DecNum(1) / ending_values.size)) - 1
     end
 
     # Weighted mean as a portfolio return
@@ -240,13 +243,12 @@ module Finrb
     # @example
     #   Finrb::Returns.wpr(r=[0.12, 0.07, 0.03],w=[0.5,0.4,0.1])
     def self.wpr(r:, w:)
-      r = wrap_array(r).map { |value| Flt::DecNum(value.to_s) }
-      w = wrap_array(w).map { |value| Flt::DecNum(value.to_s) }
+      returns = risk_values(r, name: 'return')
+      weights = risk_values(w, name: 'weight')
+      raise(ArgumentError, 'Returns and weights must have equal lengths.') unless returns.size == weights.size
+      raise(ArgumentError, 'Weights must sum to 1.') unless weights.sum == 1
 
-      # TODO: need to change
-      puts('sum of weights is NOT equal to 1!') if w.sum != 1
-
-      r.zip(w).sum { |arr| arr.reduce(:*) }
+      returns.zip(weights).sum { |rate, weight| rate * weight }
     end
   end
 end

--- a/lib/finrb/returns.rb
+++ b/lib/finrb/returns.rb
@@ -29,12 +29,9 @@ module Finrb
     # @param periods [Integer] number of equal annual periods
     # @return [Flt::DecNum] compound growth rate per period
     def self.cagr(beginning_value:, ending_value:, periods:)
-      beginning_value = Validation.decimal(beginning_value, name: 'beginning_value')
-      ending_value = Validation.decimal(ending_value, name: 'ending_value')
+      beginning_value = Validation.positive_decimal(beginning_value, name: 'beginning_value')
+      ending_value = Validation.non_negative_decimal(ending_value, name: 'ending_value')
       periods = Validation.positive_integer(periods, name: 'periods')
-
-      raise(ArgumentError, 'beginning_value must be greater than zero.') unless beginning_value.positive?
-      raise(ArgumentError, 'ending_value must be greater than or equal to zero.') if ending_value.negative?
 
       ((ending_value / beginning_value)**(Flt::DecNum(1) / periods)) - 1
     end
@@ -49,18 +46,16 @@ module Finrb
 
     # Compound a periodic return into an annual return.
     def self.annualize_return(rate:, periods_per_year:)
-      rate = Validation.decimal(rate, name: 'rate')
+      rate = Validation.decimal_at_least(rate, minimum: -1, name: 'rate')
       periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
-      raise(ArgumentError, 'rate must be greater than or equal to -1.') if rate < -1
 
       ((rate + 1)**periods_per_year) - 1
     end
 
     # Scale periodic volatility by the square root of periods per year.
     def self.annualize_volatility(volatility:, periods_per_year:)
-      volatility = Validation.decimal(volatility, name: 'volatility')
+      volatility = Validation.non_negative_decimal(volatility, name: 'volatility')
       periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
-      raise(ArgumentError, 'volatility must be greater than or equal to zero.') if volatility.negative?
 
       volatility * (Flt::DecNum(periods_per_year)**Flt::DecNum('0.5'))
     end

--- a/lib/finrb/returns.rb
+++ b/lib/finrb/returns.rb
@@ -29,9 +29,9 @@ module Finrb
     # @param periods [Integer] number of equal annual periods
     # @return [Flt::DecNum] compound growth rate per period
     def self.cagr(beginning_value:, ending_value:, periods:)
-      beginning_value = Validation.positive_decimal(beginning_value, name: 'beginning_value')
-      ending_value = Validation.non_negative_decimal(ending_value, name: 'ending_value')
-      periods = Validation.positive_integer(periods, name: 'periods')
+      beginning_value = Validation.positive_decimal(beginning_value, name: 'beginning value')
+      ending_value = Validation.non_negative_decimal(ending_value, name: 'ending value')
+      periods = Validation.positive_integer(periods, name: 'period count')
 
       ((ending_value / beginning_value)**(Flt::DecNum(1) / periods)) - 1
     end
@@ -46,8 +46,8 @@ module Finrb
 
     # Compound a periodic return into an annual return.
     def self.annualize_return(rate:, periods_per_year:)
-      rate = Validation.decimal_at_least(rate, minimum: -1, name: 'rate')
-      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      rate = Validation.decimal_at_least(rate, minimum: -1, name: 'periodic rate')
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods per year')
 
       ((rate + 1)**periods_per_year) - 1
     end
@@ -55,7 +55,7 @@ module Finrb
     # Scale periodic volatility by the square root of periods per year.
     def self.annualize_volatility(volatility:, periods_per_year:)
       volatility = Validation.non_negative_decimal(volatility, name: 'volatility')
-      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods per year')
 
       volatility * (Flt::DecNum(periods_per_year)**Flt::DecNum('0.5'))
     end
@@ -98,7 +98,7 @@ module Finrb
       ratio = ((returns.sum / returns.size) - target) / downside
       return ratio if periods_per_year.nil?
 
-      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods_per_year')
+      periods_per_year = Validation.positive_integer(periods_per_year, name: 'periods per year')
       ratio * (Flt::DecNum(periods_per_year)**Flt::DecNum('0.5'))
     end
 

--- a/lib/finrb/tvm.rb
+++ b/lib/finrb/tvm.rb
@@ -38,7 +38,7 @@ module Finrb
     def fv_annuity(r:, n:, pmt:, type: 0)
       rate = periodic_rate(r)
       periods = period_count(n)
-      payment = decimal(pmt, :pmt)
+      payment = Validation.decimal(pmt, name: 'pmt')
       payment_timing = payment_type(type)
       return -payment * periods if rate.zero?
 
@@ -48,7 +48,7 @@ module Finrb
     def fv_simple(r:, n:, pv:)
       rate = periodic_rate(r)
       periods = period_count(n)
-      present_value = decimal(pv, :pv)
+      present_value = Validation.decimal(pv, name: 'pv')
       (present_value * ((rate + 1)**periods)) * -1
     end
 
@@ -107,7 +107,7 @@ module Finrb
     def pv_annuity(r:, n:, pmt:, type: 0)
       rate = periodic_rate(r)
       periods = period_count(n)
-      payment = decimal(pmt, :pmt)
+      payment = Validation.decimal(pmt, name: 'pmt')
       payment_timing = payment_type(type)
       return -payment * periods if rate.zero?
 
@@ -116,7 +116,7 @@ module Finrb
 
     def pv_perpetuity(r:, pmt:, g: 0, type: 0)
       rate = periodic_rate(r)
-      payment = decimal(pmt, :pmt)
+      payment = Validation.decimal(pmt, name: 'pmt')
       growth = periodic_rate(g, name: :g)
       payment_timing = payment_type(type)
       raise(DomainError, 'Growth rate must be smaller than the discount rate.') if growth >= rate
@@ -127,7 +127,7 @@ module Finrb
     def pv_simple(r:, n:, fv:)
       rate = periodic_rate(r)
       periods = period_count(n)
-      future_value = decimal(fv, :fv)
+      future_value = Validation.decimal(fv, name: 'fv')
       (future_value / ((rate + 1)**periods)) * -1
     end
 
@@ -139,8 +139,8 @@ module Finrb
     end
 
     def r_perpetuity(pmt:, pv:)
-      payment = decimal(pmt, :pmt)
-      present_value = decimal(pv, :pv)
+      payment = Validation.decimal(pmt, name: 'pmt')
+      present_value = Validation.decimal(pv, name: 'pv')
       raise(DomainError, 'Present value must be non-zero.') if present_value.zero?
 
       payment * -1 / present_value
@@ -157,22 +157,17 @@ module Finrb
         end
       raise(ArgumentError, 'cf cannot be empty.') if values.empty?
 
-      values.map { |cashflow| decimal(cashflow, :cashflow) }
+      values.map { |cashflow| Validation.decimal(cashflow, name: 'cashflow') }
     end
     private_class_method :cashflow_values
 
-    def decimal(value, name)
-      Validation.decimal(value, name: name.to_s)
-    end
-    private_class_method :decimal
-
     def decimal_inputs(**values)
-      values.to_h { |name, value| [name, decimal(value, name)] }
+      values.to_h { |name, value| [name, Validation.decimal(value, name: name.to_s)] }
     end
     private_class_method :decimal_inputs
 
     def payment_type(value)
-      value = decimal(value, :type)
+      value = Validation.decimal(value, name: 'type')
       raise(ArgumentError, 'type must be 0 or 1.') unless [Flt::DecNum(0), Flt::DecNum(1)].include?(value)
 
       value
@@ -180,26 +175,17 @@ module Finrb
     private_class_method :payment_type
 
     def period_count(value)
-      value = decimal(value, :n)
-      raise(DomainError, 'n must be non-negative.') if value.negative?
-
-      value
+      Validation.non_negative_decimal(value, name: 'n', error: DomainError, message: 'n must be non-negative.')
     end
     private_class_method :period_count
 
     def positive_period_count(value)
-      value = period_count(value)
-      raise(DomainError, 'n must be greater than zero.') if value.zero?
-
-      value
+      Validation.positive_decimal(value, name: 'n', error: DomainError)
     end
     private_class_method :positive_period_count
 
     def periodic_rate(value, name: :r)
-      value = decimal(value, name)
-      raise(DomainError, "#{name} must be greater than -1.") if value <= -1
-
-      value
+      Validation.decimal_greater_than(value, minimum: -1, name: name.to_s, error: DomainError)
     end
     private_class_method :periodic_rate
 

--- a/lib/finrb/tvm.rb
+++ b/lib/finrb/tvm.rb
@@ -14,6 +14,8 @@ module Finrb
 
     UNSET_BOUND = Object.new.freeze
     private_constant :UNSET_BOUND
+    INPUT_NAMES = { fv: 'future value', g: 'growth rate', guess: 'rate guess', lower: 'lower rate bound', n: 'period count', pmt: 'payment', pv: 'present value', r: 'periodic rate', upper: 'upper rate bound' }.freeze
+    private_constant :INPUT_NAMES
 
     def discount_rate(n:, pv:, fv:, pmt:, type: 0, guess: nil, lower: UNSET_BOUND, upper: UNSET_BOUND)
       n = period_count(n)
@@ -38,7 +40,7 @@ module Finrb
     def fv_annuity(r:, n:, pmt:, type: 0)
       rate = periodic_rate(r)
       periods = period_count(n)
-      payment = Validation.decimal(pmt, name: 'pmt')
+      payment = Validation.decimal(pmt, name: 'payment')
       payment_timing = payment_type(type)
       return -payment * periods if rate.zero?
 
@@ -48,7 +50,7 @@ module Finrb
     def fv_simple(r:, n:, pv:)
       rate = periodic_rate(r)
       periods = period_count(n)
-      present_value = Validation.decimal(pv, name: 'pv')
+      present_value = Validation.decimal(pv, name: 'present value')
       (present_value * ((rate + 1)**periods)) * -1
     end
 
@@ -107,7 +109,7 @@ module Finrb
     def pv_annuity(r:, n:, pmt:, type: 0)
       rate = periodic_rate(r)
       periods = period_count(n)
-      payment = Validation.decimal(pmt, name: 'pmt')
+      payment = Validation.decimal(pmt, name: 'payment')
       payment_timing = payment_type(type)
       return -payment * periods if rate.zero?
 
@@ -116,7 +118,7 @@ module Finrb
 
     def pv_perpetuity(r:, pmt:, g: 0, type: 0)
       rate = periodic_rate(r)
-      payment = Validation.decimal(pmt, name: 'pmt')
+      payment = Validation.decimal(pmt, name: 'payment')
       growth = periodic_rate(g, name: :g)
       payment_timing = payment_type(type)
       raise(DomainError, 'Growth rate must be smaller than the discount rate.') if growth >= rate
@@ -127,7 +129,7 @@ module Finrb
     def pv_simple(r:, n:, fv:)
       rate = periodic_rate(r)
       periods = period_count(n)
-      future_value = Validation.decimal(fv, name: 'fv')
+      future_value = Validation.decimal(fv, name: 'future value')
       (future_value / ((rate + 1)**periods)) * -1
     end
 
@@ -139,8 +141,8 @@ module Finrb
     end
 
     def r_perpetuity(pmt:, pv:)
-      payment = Validation.decimal(pmt, name: 'pmt')
-      present_value = Validation.decimal(pv, name: 'pv')
+      payment = Validation.decimal(pmt, name: 'payment')
+      present_value = Validation.decimal(pv, name: 'present value')
       raise(DomainError, 'Present value must be non-zero.') if present_value.zero?
 
       payment * -1 / present_value
@@ -155,39 +157,44 @@ module Finrb
         else
           [value]
         end
-      raise(ArgumentError, 'cf cannot be empty.') if values.empty?
+      raise(ArgumentError, 'cashflows cannot be empty.') if values.empty?
 
       values.map { |cashflow| Validation.decimal(cashflow, name: 'cashflow') }
     end
     private_class_method :cashflow_values
 
     def decimal_inputs(**values)
-      values.to_h { |name, value| [name, Validation.decimal(value, name: name.to_s)] }
+      values.to_h { |name, value| [name, Validation.decimal(value, name: input_name(name))] }
     end
     private_class_method :decimal_inputs
 
     def payment_type(value)
-      value = Validation.decimal(value, name: 'type')
-      raise(ArgumentError, 'type must be 0 or 1.') unless [Flt::DecNum(0), Flt::DecNum(1)].include?(value)
+      value = Validation.decimal(value, name: 'payment timing type')
+      raise(ArgumentError, 'payment timing type must be 0 (end) or 1 (beginning).') unless [Flt::DecNum(0), Flt::DecNum(1)].include?(value)
 
       value
     end
     private_class_method :payment_type
 
     def period_count(value)
-      Validation.non_negative_decimal(value, name: 'n', error: DomainError, message: 'n must be non-negative.')
+      Validation.non_negative_decimal(value, name: 'period count', error: DomainError)
     end
     private_class_method :period_count
 
     def positive_period_count(value)
-      Validation.positive_decimal(value, name: 'n', error: DomainError)
+      Validation.positive_decimal(value, name: 'period count', error: DomainError)
     end
     private_class_method :positive_period_count
 
     def periodic_rate(value, name: :r)
-      Validation.decimal_greater_than(value, minimum: -1, name: name.to_s, error: DomainError)
+      Validation.decimal_greater_than(value, minimum: -1, name: input_name(name), error: DomainError)
     end
     private_class_method :periodic_rate
+
+    def input_name(name)
+      INPUT_NAMES.fetch(name, name.to_s.tr('_', ' '))
+    end
+    private_class_method :input_name
 
     def rate_bounds(function, guess:, lower:, upper:)
       return searched_rate_bounds(function, guess) if lower.equal?(UNSET_BOUND) && upper.equal?(UNSET_BOUND)
@@ -196,7 +203,7 @@ module Finrb
       upper = 100 if upper.equal?(UNSET_BOUND)
       lower = periodic_rate(lower, name: :lower)
       upper = periodic_rate(upper, name: :upper)
-      raise(ArgumentError, 'lower must be less than upper.') if lower >= upper
+      raise(ArgumentError, 'lower rate bound must be less than upper rate bound.') if lower >= upper
 
       [lower, upper]
     end

--- a/lib/finrb/tvm.rb
+++ b/lib/finrb/tvm.rb
@@ -4,123 +4,232 @@ require_relative 'config'
 require_relative 'decimal'
 require_relative 'errors'
 require_relative 'numerical/brent'
+require_relative 'numerical/rate_search'
+require_relative 'validation'
 
 module Finrb
   # Time-value-of-money calculations for periodic rates and cashflows.
   module TVM
     module_function
 
-    def discount_rate(n:, pv:, fv:, pmt:, type: 0, lower: 0.0001, upper: 100)
-      n, pv, fv, pmt, type, lower, upper = decimals(n, pv, fv, pmt, type, lower, upper)
+    UNSET_BOUND = Object.new.freeze
+    private_constant :UNSET_BOUND
+
+    def discount_rate(n:, pv:, fv:, pmt:, type: 0, guess: nil, lower: UNSET_BOUND, upper: UNSET_BOUND)
+      n = period_count(n)
+      pv, fv, pmt = decimal_inputs(pv:, fv:, pmt:).values
+      type = payment_type(type)
       function = ->(rate) { fv_simple(r: rate, n:, pv:) + fv_annuity(r: rate, n:, pmt:, type:) - fv }
 
-      Numerical::Brent.new(tolerance: Finrb.config.eps).solve(function, lower:, upper:)
+      bounds = rate_bounds(function, guess:, lower:, upper:)
+      return bounds.first if bounds.first == bounds.last
+
+      Numerical::Brent.new(tolerance: Finrb.config.eps).solve(function, lower: bounds.first, upper: bounds.last)
     end
 
     def fv(r:, n:, pv: 0, pmt: 0, type: 0)
-      r, n, pv, pmt, type = decimals(r, n, pv, pmt, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      payment_type(type)
 
-      fv_simple(r:, n:, pv:) + fv_annuity(r:, n:, pmt:, type:)
+      fv_simple(r: rate, n: periods, pv:) + fv_annuity(r: rate, n: periods, pmt:, type:)
     end
 
     def fv_annuity(r:, n:, pmt:, type: 0)
-      r, n, pmt, type = decimals(r, n, pmt, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      payment = decimal(pmt, :pmt)
+      payment_timing = payment_type(type)
+      return -payment * periods if rate.zero?
 
-      (pmt / r * (((r + 1)**n) - 1)) * ((r + 1)**type) * -1
+      (payment / rate * (((rate + 1)**periods) - 1)) * ((rate + 1)**payment_timing) * -1
     end
 
     def fv_simple(r:, n:, pv:)
-      r, n, pv = decimals(r, n, pv)
-      (pv * ((r + 1)**n)) * -1
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      present_value = decimal(pv, :pv)
+      (present_value * ((rate + 1)**periods)) * -1
     end
 
     def fv_uneven(r:, cf:)
-      r = Flt::DecNum(r.to_s)
-      cashflows = array(cf).map { |value| Flt::DecNum(value.to_s) }
+      rate = periodic_rate(r)
+      cashflows = cashflow_values(cf)
 
       cashflows.each_with_index.sum do |cashflow, index|
-        fv_simple(r:, n: cashflows.size - index - 1, pv: cashflow)
+        fv_simple(r: rate, n: cashflows.size - index - 1, pv: cashflow)
       end
     end
 
     def n_period(r:, pv:, fv:, pmt:, type: 0)
-      r, pv, fv, pmt, type = decimals(r, pv, fv, pmt, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      values = decimal_inputs(pv:, fv:, pmt:)
+      payment_timing = payment_type(type)
 
-      numerator = ((fv * r) - (pmt * ((r + 1)**type))) * -1
-      denominator = (pv * r) + (pmt * ((r + 1)**type))
-      (numerator / denominator).log / (r + 1).log
+      return zero_rate_periods(**values) if rate.zero?
+
+      numerator = ((values[:fv] * rate) - (values[:pmt] * ((rate + 1)**payment_timing))) * -1
+      denominator = (values[:pv] * rate) + (values[:pmt] * ((rate + 1)**payment_timing))
+      periods = (numerator / denominator).log / (rate + 1).log
+      raise(DomainError, 'Inputs do not produce a finite non-negative period count.') unless periods.finite? && !periods.negative?
+
+      periods
+    rescue Flt::Num::Exception, Math::DomainError, ZeroDivisionError => e
+      raise(DomainError, "Inputs do not produce a real period count: #{e.message}", e.backtrace)
     end
 
     def npv(r:, cf:)
-      cashflows = array(cf).map { |value| Flt::DecNum(value.to_s) }
-      (pv_uneven(r:, cf: cashflows.drop(1)) * -1) + cashflows.first
+      rate = periodic_rate(r)
+      cashflows = cashflow_values(cf)
+      return cashflows.first if cashflows.one?
+
+      (pv_uneven(r: rate, cf: cashflows.drop(1)) * -1) + cashflows.first
     end
 
     def pmt(r:, n:, pv:, fv:, type: 0)
-      r, n, pv, fv, type = decimals(r, n, pv, fv, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      periods = positive_period_count(n)
+      values = decimal_inputs(pv:, fv:)
+      payment_timing = payment_type(type)
+      return -(values[:pv] + values[:fv]) / periods if rate.zero?
 
-      (pv + (fv / ((r + 1)**n))) * r / (1 - (Flt::DecNum(1) / ((r + 1)**n))) * -1 * ((r + 1)**(type * -1))
+      (values[:pv] + (values[:fv] / ((rate + 1)**periods))) * rate / (1 - (Flt::DecNum(1) / ((rate + 1)**periods))) * -1 * ((rate + 1)**(payment_timing * -1))
     end
 
     def pv(r:, n:, fv: 0, pmt: 0, type: 0)
-      r, n, fv, pmt, type = decimals(r, n, fv, pmt, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      payment_type(type)
 
-      pv_simple(r:, n:, fv:) + pv_annuity(r:, n:, pmt:, type:)
+      pv_simple(r: rate, n: periods, fv:) + pv_annuity(r: rate, n: periods, pmt:, type:)
     end
 
     def pv_annuity(r:, n:, pmt:, type: 0)
-      r, n, pmt, type = decimals(r, n, pmt, type)
-      validate_payment_type!(type)
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      payment = decimal(pmt, :pmt)
+      payment_timing = payment_type(type)
+      return -payment * periods if rate.zero?
 
-      (pmt / r * (1 - (Flt::DecNum(1) / ((r + 1)**n)))) * ((r + 1)**type) * -1
+      (payment / rate * (1 - (Flt::DecNum(1) / ((rate + 1)**periods)))) * ((rate + 1)**payment_timing) * -1
     end
 
     def pv_perpetuity(r:, pmt:, g: 0, type: 0)
-      r, pmt, g, type = decimals(r, pmt, g, type)
-      validate_payment_type!(type)
-      raise(Error, 'Error: g is not smaller than r!') if g >= r
+      rate = periodic_rate(r)
+      payment = decimal(pmt, :pmt)
+      growth = periodic_rate(g, name: :g)
+      payment_timing = payment_type(type)
+      raise(DomainError, 'Growth rate must be smaller than the discount rate.') if growth >= rate
 
-      (pmt / (r - g)) * ((r + 1)**type) * -1
+      (payment / (rate - growth)) * ((rate + 1)**payment_timing) * -1
     end
 
     def pv_simple(r:, n:, fv:)
-      r, n, fv = decimals(r, n, fv)
-      (fv / ((r + 1)**n)) * -1
+      rate = periodic_rate(r)
+      periods = period_count(n)
+      future_value = decimal(fv, :fv)
+      (future_value / ((rate + 1)**periods)) * -1
     end
 
     def pv_uneven(r:, cf:)
-      r = Flt::DecNum(r.to_s)
-      array(cf).each_with_index.sum do |cashflow, index|
-        pv_simple(r:, n: index + 1, fv: cashflow)
+      rate = periodic_rate(r)
+      cashflow_values(cf).each_with_index.sum do |cashflow, index|
+        pv_simple(r: rate, n: index + 1, fv: cashflow)
       end
     end
 
     def r_perpetuity(pmt:, pv:)
-      pmt, pv = decimals(pmt, pv)
-      pmt * -1 / pv
+      payment = decimal(pmt, :pmt)
+      present_value = decimal(pv, :pv)
+      raise(DomainError, 'Present value must be non-zero.') if present_value.zero?
+
+      payment * -1 / present_value
     end
 
-    def array(value)
-      return [] if value.nil?
-      return value.to_ary || [value] if value.respond_to?(:to_ary)
+    def cashflow_values(value)
+      values =
+        if value.nil?
+          []
+        elsif value.respond_to?(:to_ary)
+          value.to_ary || [value]
+        else
+          [value]
+        end
+      raise(ArgumentError, 'cf cannot be empty.') if values.empty?
 
-      [value]
+      values.map { |cashflow| decimal(cashflow, :cashflow) }
     end
-    private_class_method :array
+    private_class_method :cashflow_values
 
-    def decimals(*values)
-      values.map { |value| Flt::DecNum(value.to_s) }
+    def decimal(value, name)
+      Validation.decimal(value, name: name.to_s)
     end
-    private_class_method :decimals
+    private_class_method :decimal
 
-    def validate_payment_type!(type)
-      raise(Error, 'Error: type should be 0 or 1!') unless [Flt::DecNum(0), Flt::DecNum(1)].include?(type)
+    def decimal_inputs(**values)
+      values.to_h { |name, value| [name, decimal(value, name)] }
     end
-    private_class_method :validate_payment_type!
+    private_class_method :decimal_inputs
+
+    def payment_type(value)
+      value = decimal(value, :type)
+      raise(ArgumentError, 'type must be 0 or 1.') unless [Flt::DecNum(0), Flt::DecNum(1)].include?(value)
+
+      value
+    end
+    private_class_method :payment_type
+
+    def period_count(value)
+      value = decimal(value, :n)
+      raise(DomainError, 'n must be non-negative.') if value.negative?
+
+      value
+    end
+    private_class_method :period_count
+
+    def positive_period_count(value)
+      value = period_count(value)
+      raise(DomainError, 'n must be greater than zero.') if value.zero?
+
+      value
+    end
+    private_class_method :positive_period_count
+
+    def periodic_rate(value, name: :r)
+      value = decimal(value, name)
+      raise(DomainError, "#{name} must be greater than -1.") if value <= -1
+
+      value
+    end
+    private_class_method :periodic_rate
+
+    def rate_bounds(function, guess:, lower:, upper:)
+      return searched_rate_bounds(function, guess) if lower.equal?(UNSET_BOUND) && upper.equal?(UNSET_BOUND)
+
+      lower = '0.0001' if lower.equal?(UNSET_BOUND)
+      upper = 100 if upper.equal?(UNSET_BOUND)
+      lower = periodic_rate(lower, name: :lower)
+      upper = periodic_rate(upper, name: :upper)
+      raise(ArgumentError, 'lower must be less than upper.') if lower >= upper
+
+      [lower, upper]
+    end
+    private_class_method :rate_bounds
+
+    def searched_rate_bounds(function, guess)
+      guess = Finrb.config.guess if guess.nil?
+      Numerical::RateSearch.new.bracket(function, guess: periodic_rate(guess, name: :guess))
+    end
+    private_class_method :searched_rate_bounds
+
+    def zero_rate_periods(pv:, fv:, pmt:)
+      raise(DomainError, 'pmt must be non-zero when solving periods at a zero rate.') if pmt.zero?
+
+      periods = (-pv - fv) / pmt
+      raise(DomainError, 'Inputs do not produce a non-negative period count.') if periods.negative?
+
+      periods
+    end
+    private_class_method :zero_rate_periods
   end
 end

--- a/lib/finrb/validation.rb
+++ b/lib/finrb/validation.rb
@@ -51,5 +51,19 @@ module Finrb
 
       decimal
     end
+
+    def non_zero_decimal(value, name:, error: ArgumentError)
+      decimal = decimal(value, name:)
+      raise(error, "#{name} must be non-zero.") if decimal.zero?
+
+      decimal
+    end
+
+    def decimal_between(value, minimum:, maximum:, name:, error: ArgumentError)
+      decimal = decimal(value, name:)
+      raise(error, "#{name} must be between #{minimum} and #{maximum}, inclusive.") unless decimal.between?(minimum, maximum)
+
+      decimal
+    end
   end
 end

--- a/lib/finrb/validation.rb
+++ b/lib/finrb/validation.rb
@@ -23,5 +23,33 @@ module Finrb
 
       value
     end
+
+    def positive_decimal(value, name:, error: ArgumentError, message: nil)
+      decimal = decimal(value, name:)
+      raise(error, message || "#{name} must be greater than zero.") unless decimal.positive?
+
+      decimal
+    end
+
+    def non_negative_decimal(value, name:, error: ArgumentError, message: nil)
+      decimal = decimal(value, name:)
+      raise(error, message || "#{name} must be greater than or equal to zero.") if decimal.negative?
+
+      decimal
+    end
+
+    def decimal_greater_than(value, minimum:, name:, error: ArgumentError)
+      decimal = decimal(value, name:)
+      raise(error, "#{name} must be greater than #{minimum}.") if decimal <= minimum
+
+      decimal
+    end
+
+    def decimal_at_least(value, minimum:, name:, error: ArgumentError)
+      decimal = decimal(value, name:)
+      raise(error, "#{name} must be greater than or equal to #{minimum}.") if decimal < minimum
+
+      decimal
+    end
   end
 end

--- a/lib/finrb/version.rb
+++ b/lib/finrb/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Finrb
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
   public_constant :VERSION
 end

--- a/lib/finrb/yields.rb
+++ b/lib/finrb/yields.rb
@@ -15,9 +15,9 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy(d=1500,f=100000,t=120)
     def self.bdy(d:, f:, t:)
-      d = decimal(d, name: 'd')
-      f = positive(f, name: 'f')
-      t = positive(t, name: 't')
+      d = Validation.decimal(d, name: 'd')
+      f = Validation.positive_decimal(f, name: 'f', error: DomainError)
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       (d * 360 / f / t)
     end
@@ -29,8 +29,8 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy2mmy(bdy=0.045,t=120)
     def self.bdy2mmy(bdy:, t:)
-      bdy = decimal(bdy, name: 'bdy')
-      t = positive(t, name: 't')
+      bdy = Validation.decimal(bdy, name: 'bdy')
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
       denominator = 360 - (t * bdy)
       raise(DomainError, 'bdy and t must imply a positive purchase price.') unless denominator.positive?
 
@@ -47,8 +47,8 @@ module Finrb
     # @example
     #   Finrb::Yields.ear(0.04,365)
     def self.ear(r:, m:)
-      r = decimal(r, name: 'r')
-      m = positive(m, name: 'm')
+      r = Validation.decimal(r, name: 'r')
+      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
 
       ((compounding_base(r, m)**m) - 1)
     end
@@ -62,7 +62,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear_continuous(0.03)
     def self.ear_continuous(r:)
-      r = decimal(r, name: 'r')
+      r = Validation.decimal(r, name: 'r')
 
       (r.exp - 1)
     end
@@ -73,7 +73,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2bey(ear=0.08)
     def self.ear2bey(ear:)
-      ear = total_return(ear, name: 'ear')
+      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'ear', error: DomainError)
 
       (((ear + 1).sqrt - 1) * 2)
     end
@@ -85,8 +85,8 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2hpr(ear=0.05039,t=150)
     def self.ear2hpr(ear:, t:)
-      ear = total_return(ear, name: 'ear')
-      t = positive(t, name: 't')
+      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'ear', error: DomainError)
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       (((ear + 1)**(t / 365)) - 1)
     end
@@ -127,9 +127,9 @@ module Finrb
     #   # monthly proportional interest rate which is equivalent to a simple annual interest
     #   Finrb::Yields.eir(r=0.05,p=12,type='p')
     def self.eir(r:, n: 1, p: 12, type: 'e')
-      r = decimal(r, name: 'r')
-      n = positive(n, name: 'n')
-      p = positive(p, name: 'p')
+      r = Validation.decimal(r, name: 'r')
+      n = Validation.positive_decimal(n, name: 'n', error: DomainError)
+      p = Validation.positive_decimal(p, name: 'p', error: DomainError)
       type = type.to_s
 
       case type
@@ -150,8 +150,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2bey(hpr=0.02,t=3)
     def self.hpr2bey(hpr:, t:)
-      hpr = total_return(hpr, name: 'hpr')
-      t = positive(t, name: 't')
+      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'hpr', error: DomainError)
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       ((((hpr + 1)**(6 / t)) - 1) * 2)
     end
@@ -163,8 +163,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2ear(hpr=0.015228,t=120)
     def self.hpr2ear(hpr:, t:)
-      hpr = total_return(hpr, name: 'hpr')
-      t = positive(t, name: 't')
+      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'hpr', error: DomainError)
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       (((hpr + 1)**(365 / t)) - 1)
     end
@@ -176,8 +176,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2mmy(hpr=0.01523,t=120)
     def self.hpr2mmy(hpr:, t:)
-      hpr = decimal(hpr, name: 'hpr')
-      t = positive(t, name: 't')
+      hpr = Validation.decimal(hpr, name: 'hpr')
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       (hpr * 360 / t)
     end
@@ -189,8 +189,8 @@ module Finrb
     # @example
     #   Finrb::Yields.mmy2hpr(mmy=0.04898,t=150)
     def self.mmy2hpr(mmy:, t:)
-      mmy = decimal(mmy, name: 'mmy')
-      t = positive(t, name: 't')
+      mmy = Validation.decimal(mmy, name: 'mmy')
+      t = Validation.positive_decimal(t, name: 't', error: DomainError)
 
       (mmy * t / 360)
     end
@@ -202,8 +202,8 @@ module Finrb
     # @example
     #   Finrb::Yields.r_continuous(r=0.03,m=4)
     def self.r_continuous(r:, m:)
-      r = decimal(r, name: 'r')
-      m = positive(m, name: 'm')
+      r = Validation.decimal(r, name: 'r')
+      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
 
       (m * compounding_base(r, m).log)
     end
@@ -218,32 +218,11 @@ module Finrb
     # @example
     #   Finrb::Yields.r_norminal(rc=0.03,m=4)
     def self.r_norminal(rc:, m:)
-      rc = decimal(rc, name: 'rc')
-      m = positive(m, name: 'm')
+      rc = Validation.decimal(rc, name: 'rc')
+      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
 
       (m * ((rc / m).exp - 1))
     end
-
-    def self.decimal(value, name:)
-      Validation.decimal(value, name:)
-    end
-    private_class_method :decimal
-
-    def self.positive(value, name:)
-      value = decimal(value, name:)
-      raise(DomainError, "#{name} must be greater than zero.") unless value.positive?
-
-      value
-    end
-    private_class_method :positive
-
-    def self.total_return(value, name:)
-      value = decimal(value, name:)
-      raise(DomainError, "#{name} must be greater than or equal to -1.") if value < -1
-
-      value
-    end
-    private_class_method :total_return
 
     def self.compounding_base(rate, periods)
       base = (rate / periods) + 1

--- a/lib/finrb/yields.rb
+++ b/lib/finrb/yields.rb
@@ -15,9 +15,9 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy(d=1500,f=100000,t=120)
     def self.bdy(d:, f:, t:)
-      d = Validation.decimal(d, name: 'd')
-      f = Validation.positive_decimal(f, name: 'f', error: DomainError)
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      d = Validation.decimal(d, name: 'dollar discount')
+      f = Validation.positive_decimal(f, name: 'face value', error: DomainError)
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       (d * 360 / f / t)
     end
@@ -29,10 +29,10 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy2mmy(bdy=0.045,t=120)
     def self.bdy2mmy(bdy:, t:)
-      bdy = Validation.decimal(bdy, name: 'bdy')
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      bdy = Validation.decimal(bdy, name: 'bank discount yield')
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
       denominator = 360 - (t * bdy)
-      raise(DomainError, 'bdy and t must imply a positive purchase price.') unless denominator.positive?
+      raise(DomainError, 'Bank discount yield and time to maturity must imply a positive purchase price.') unless denominator.positive?
 
       (bdy * 360 / denominator)
     end
@@ -47,8 +47,8 @@ module Finrb
     # @example
     #   Finrb::Yields.ear(0.04,365)
     def self.ear(r:, m:)
-      r = Validation.decimal(r, name: 'r')
-      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
+      r = Validation.decimal(r, name: 'stated annual rate')
+      m = Validation.positive_decimal(m, name: 'compounding periods', error: DomainError)
 
       ((compounding_base(r, m)**m) - 1)
     end
@@ -62,7 +62,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear_continuous(0.03)
     def self.ear_continuous(r:)
-      r = Validation.decimal(r, name: 'r')
+      r = Validation.decimal(r, name: 'stated annual rate')
 
       (r.exp - 1)
     end
@@ -73,7 +73,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2bey(ear=0.08)
     def self.ear2bey(ear:)
-      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'ear', error: DomainError)
+      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'effective annual rate', error: DomainError)
 
       (((ear + 1).sqrt - 1) * 2)
     end
@@ -85,8 +85,8 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2hpr(ear=0.05039,t=150)
     def self.ear2hpr(ear:, t:)
-      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'ear', error: DomainError)
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      ear = Validation.decimal_at_least(ear, minimum: -1, name: 'effective annual rate', error: DomainError)
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       (((ear + 1)**(t / 365)) - 1)
     end
@@ -127,9 +127,9 @@ module Finrb
     #   # monthly proportional interest rate which is equivalent to a simple annual interest
     #   Finrb::Yields.eir(r=0.05,p=12,type='p')
     def self.eir(r:, n: 1, p: 12, type: 'e')
-      r = Validation.decimal(r, name: 'r')
-      n = Validation.positive_decimal(n, name: 'n', error: DomainError)
-      p = Validation.positive_decimal(p, name: 'p', error: DomainError)
+      r = Validation.decimal(r, name: 'annual rate')
+      n = Validation.positive_decimal(n, name: 'source compounding periods', error: DomainError)
+      p = Validation.positive_decimal(p, name: 'target compounding periods', error: DomainError)
       type = type.to_s
 
       case type
@@ -138,7 +138,7 @@ module Finrb
       when 'p'
         eir = r / p
       else
-        raise(ArgumentError, "type must be 'e' or 'p'")
+        raise(ArgumentError, "conversion type must be 'e' (equivalent) or 'p' (proportional)")
       end
       eir
     end
@@ -150,8 +150,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2bey(hpr=0.02,t=3)
     def self.hpr2bey(hpr:, t:)
-      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'hpr', error: DomainError)
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'holding period return', error: DomainError)
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       ((((hpr + 1)**(6 / t)) - 1) * 2)
     end
@@ -163,8 +163,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2ear(hpr=0.015228,t=120)
     def self.hpr2ear(hpr:, t:)
-      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'hpr', error: DomainError)
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      hpr = Validation.decimal_at_least(hpr, minimum: -1, name: 'holding period return', error: DomainError)
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       (((hpr + 1)**(365 / t)) - 1)
     end
@@ -176,8 +176,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2mmy(hpr=0.01523,t=120)
     def self.hpr2mmy(hpr:, t:)
-      hpr = Validation.decimal(hpr, name: 'hpr')
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      hpr = Validation.decimal(hpr, name: 'holding period return')
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       (hpr * 360 / t)
     end
@@ -189,8 +189,8 @@ module Finrb
     # @example
     #   Finrb::Yields.mmy2hpr(mmy=0.04898,t=150)
     def self.mmy2hpr(mmy:, t:)
-      mmy = Validation.decimal(mmy, name: 'mmy')
-      t = Validation.positive_decimal(t, name: 't', error: DomainError)
+      mmy = Validation.decimal(mmy, name: 'money market yield')
+      t = Validation.positive_decimal(t, name: 'time to maturity', error: DomainError)
 
       (mmy * t / 360)
     end
@@ -202,8 +202,8 @@ module Finrb
     # @example
     #   Finrb::Yields.r_continuous(r=0.03,m=4)
     def self.r_continuous(r:, m:)
-      r = Validation.decimal(r, name: 'r')
-      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
+      r = Validation.decimal(r, name: 'nominal rate')
+      m = Validation.positive_decimal(m, name: 'compounding periods', error: DomainError)
 
       (m * compounding_base(r, m).log)
     end
@@ -218,8 +218,8 @@ module Finrb
     # @example
     #   Finrb::Yields.r_norminal(rc=0.03,m=4)
     def self.r_norminal(rc:, m:)
-      rc = Validation.decimal(rc, name: 'rc')
-      m = Validation.positive_decimal(m, name: 'm', error: DomainError)
+      rc = Validation.decimal(rc, name: 'continuously compounded rate')
+      m = Validation.positive_decimal(m, name: 'compounding periods', error: DomainError)
 
       (m * ((rc / m).exp - 1))
     end

--- a/lib/finrb/yields.rb
+++ b/lib/finrb/yields.rb
@@ -2,6 +2,7 @@
 
 require_relative 'decimal'
 require_relative 'errors'
+require_relative 'validation'
 
 module Finrb
   # Money-market yield and interest-rate conversion calculations.
@@ -14,9 +15,9 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy(d=1500,f=100000,t=120)
     def self.bdy(d:, f:, t:)
-      d = Flt::DecNum(d.to_s)
-      f = Flt::DecNum(f.to_s)
-      t = Flt::DecNum(t.to_s)
+      d = decimal(d, name: 'd')
+      f = positive(f, name: 'f')
+      t = positive(t, name: 't')
 
       (d * 360 / f / t)
     end
@@ -28,10 +29,12 @@ module Finrb
     # @example
     #   Finrb::Yields.bdy2mmy(bdy=0.045,t=120)
     def self.bdy2mmy(bdy:, t:)
-      bdy = Flt::DecNum(bdy.to_s)
-      t = Flt::DecNum(t.to_s)
+      bdy = decimal(bdy, name: 'bdy')
+      t = positive(t, name: 't')
+      denominator = 360 - (t * bdy)
+      raise(DomainError, 'bdy and t must imply a positive purchase price.') unless denominator.positive?
 
-      (bdy * 360 / (360 - (t * bdy)))
+      (bdy * 360 / denominator)
     end
 
     # Convert stated annual rate to the effective annual rate
@@ -44,10 +47,10 @@ module Finrb
     # @example
     #   Finrb::Yields.ear(0.04,365)
     def self.ear(r:, m:)
-      r = Flt::DecNum(r.to_s)
-      m = Flt::DecNum(m.to_s)
+      r = decimal(r, name: 'r')
+      m = positive(m, name: 'm')
 
-      ((((r / m) + 1)**m) - 1)
+      ((compounding_base(r, m)**m) - 1)
     end
 
     # Convert stated annual rate to the effective annual rate with continuous compounding
@@ -59,7 +62,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear_continuous(0.03)
     def self.ear_continuous(r:)
-      r = Flt::DecNum(r.to_s)
+      r = decimal(r, name: 'r')
 
       (r.exp - 1)
     end
@@ -70,7 +73,7 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2bey(ear=0.08)
     def self.ear2bey(ear:)
-      ear = Flt::DecNum(ear.to_s)
+      ear = total_return(ear, name: 'ear')
 
       (((ear + 1).sqrt - 1) * 2)
     end
@@ -82,8 +85,8 @@ module Finrb
     # @example
     #   Finrb::Yields.ear2hpr(ear=0.05039,t=150)
     def self.ear2hpr(ear:, t:)
-      ear = Flt::DecNum(ear.to_s)
-      t = Flt::DecNum(t.to_s)
+      ear = total_return(ear, name: 'ear')
+      t = positive(t, name: 't')
 
       (((ear + 1)**(t / 365)) - 1)
     end
@@ -124,18 +127,18 @@ module Finrb
     #   # monthly proportional interest rate which is equivalent to a simple annual interest
     #   Finrb::Yields.eir(r=0.05,p=12,type='p')
     def self.eir(r:, n: 1, p: 12, type: 'e')
-      r = Flt::DecNum(r.to_s)
-      n = Flt::DecNum(n.to_s)
-      p = Flt::DecNum(p.to_s)
+      r = decimal(r, name: 'r')
+      n = positive(n, name: 'n')
+      p = positive(p, name: 'p')
       type = type.to_s
 
       case type
       when 'e'
-        eir = (((r / n) + 1)**(n / p)) - 1
+        eir = (compounding_base(r, n)**(n / p)) - 1
       when 'p'
         eir = r / p
       else
-        raise(Error, "type must be 'e' or 'p'")
+        raise(ArgumentError, "type must be 'e' or 'p'")
       end
       eir
     end
@@ -147,8 +150,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2bey(hpr=0.02,t=3)
     def self.hpr2bey(hpr:, t:)
-      hpr = Flt::DecNum(hpr.to_s)
-      t = Flt::DecNum(t.to_s)
+      hpr = total_return(hpr, name: 'hpr')
+      t = positive(t, name: 't')
 
       ((((hpr + 1)**(6 / t)) - 1) * 2)
     end
@@ -160,8 +163,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2ear(hpr=0.015228,t=120)
     def self.hpr2ear(hpr:, t:)
-      hpr = Flt::DecNum(hpr.to_s)
-      t = Flt::DecNum(t.to_s)
+      hpr = total_return(hpr, name: 'hpr')
+      t = positive(t, name: 't')
 
       (((hpr + 1)**(365 / t)) - 1)
     end
@@ -173,8 +176,8 @@ module Finrb
     # @example
     #   Finrb::Yields.hpr2mmy(hpr=0.01523,t=120)
     def self.hpr2mmy(hpr:, t:)
-      hpr = Flt::DecNum(hpr.to_s)
-      t = Flt::DecNum(t.to_s)
+      hpr = decimal(hpr, name: 'hpr')
+      t = positive(t, name: 't')
 
       (hpr * 360 / t)
     end
@@ -186,8 +189,8 @@ module Finrb
     # @example
     #   Finrb::Yields.mmy2hpr(mmy=0.04898,t=150)
     def self.mmy2hpr(mmy:, t:)
-      mmy = Flt::DecNum(mmy.to_s)
-      t = Flt::DecNum(t.to_s)
+      mmy = decimal(mmy, name: 'mmy')
+      t = positive(t, name: 't')
 
       (mmy * t / 360)
     end
@@ -199,10 +202,10 @@ module Finrb
     # @example
     #   Finrb::Yields.r_continuous(r=0.03,m=4)
     def self.r_continuous(r:, m:)
-      r = Flt::DecNum(r.to_s)
-      m = Flt::DecNum(m.to_s)
+      r = decimal(r, name: 'r')
+      m = positive(m, name: 'm')
 
-      (m * ((r / m) + 1).log)
+      (m * compounding_base(r, m).log)
     end
 
     # Convert a given continuous compounded rate to a norminal rate
@@ -215,10 +218,39 @@ module Finrb
     # @example
     #   Finrb::Yields.r_norminal(rc=0.03,m=4)
     def self.r_norminal(rc:, m:)
-      rc = Flt::DecNum(rc.to_s)
-      m = Flt::DecNum(m.to_s)
+      rc = decimal(rc, name: 'rc')
+      m = positive(m, name: 'm')
 
       (m * ((rc / m).exp - 1))
     end
+
+    def self.decimal(value, name:)
+      Validation.decimal(value, name:)
+    end
+    private_class_method :decimal
+
+    def self.positive(value, name:)
+      value = decimal(value, name:)
+      raise(DomainError, "#{name} must be greater than zero.") unless value.positive?
+
+      value
+    end
+    private_class_method :positive
+
+    def self.total_return(value, name:)
+      value = decimal(value, name:)
+      raise(DomainError, "#{name} must be greater than or equal to -1.") if value < -1
+
+      value
+    end
+    private_class_method :total_return
+
+    def self.compounding_base(rate, periods)
+      base = (rate / periods) + 1
+      raise(DomainError, 'The rate per compounding period must be greater than -1.') unless base.positive?
+
+      base
+    end
+    private_class_method :compounding_base
   end
 end

--- a/script/benchmark_finrb.rb
+++ b/script/benchmark_finrb.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require('benchmark/ips')
+require('date')
+require('optparse')
+require_relative('../lib/finrb')
+
+# Deterministic benchmark scenarios and correctness preflight for finrb.
+module FinrbBenchmark
+  Scenario = Data.define(:name, :operation, :residual)
+  class VerificationError < StandardError; end
+  MAX_NORMALIZED_RESIDUAL = Flt::DecNum('1e-12')
+  private_constant :Scenario, :VerificationError, :MAX_NORMALIZED_RESIDUAL
+
+  # Counts solver objective evaluations without changing production APIs.
+  module EvaluationCounter
+    def npv(rate)
+      FinrbBenchmark.increment_evaluations
+      super
+    end
+
+    def xnpv(rate)
+      FinrbBenchmark.increment_evaluations
+      super
+    end
+  end
+  private_constant :EvaluationCounter
+
+  module_function
+
+  def increment_evaluations
+    Thread.current[:finrb_benchmark_evaluations] = evaluations + 1
+  end
+
+  def evaluations
+    Thread.current[:finrb_benchmark_evaluations] || 0
+  end
+
+  def reset_evaluations
+    Thread.current[:finrb_benchmark_evaluations] = 0
+  end
+
+  def periodic_cashflows(size:, rate:)
+    terminal = Flt::DecNum(1000) * ((Flt::DecNum(1) + rate)**(size - 1))
+    [-Flt::DecNum(1000), *Array.new(size - 2, Flt::DecNum(0)), terminal]
+  end
+
+  def dated_cashflows(size:, rate:, random:)
+    start_date = Date.new(2000, 1, 1)
+    offsets = Array.new(size) { |index| (index * 17) + random.rand(0..3) }
+    offsets[0] = 0
+    offsets.each_cons(2).with_index { |(left, right), index| offsets[index + 1] = left + 1 if right <= left }
+    terminal = Flt::DecNum(1000) * ((Flt::DecNum(1) + rate)**(Flt::DecNum(offsets.last) / 365))
+
+    offsets.each_with_index.map do |offset, index|
+      amount = index.zero? ? -Flt::DecNum(1000) : Flt::DecNum(0)
+      amount = terminal if index == offsets.size - 1
+      Finrb::Transaction.new(amount, date: start_date + offset)
+    end
+  end
+
+  def normalized_residual(cashflows, rate, function)
+    residual = Finrb::Cashflow.public_send(function, cashflows, rate).abs
+    scale = cashflows.sum { |entry| entry.respond_to?(:amount) ? entry.amount.abs : entry.abs }
+    residual / scale
+  end
+
+  def solver_scenario(kind:, size:, rate:, guess:, random:)
+    cashflows = kind == :irr ? periodic_cashflows(size:, rate:) : dated_cashflows(size:, rate:, random:)
+    solve = kind == :irr ? :irr : :xirr
+    residual_function = kind == :irr ? :npv : :xnpv
+    operation =
+      lambda do
+        result = Finrb::Cashflow.public_send(solve, cashflows, guess)
+        result.respond_to?(:effective) ? result.effective : result
+      end
+
+    Scenario.new("#{kind}/#{size}", operation, ->(result) { normalized_residual(cashflows, result, residual_function) })
+  end
+
+  def amortization_scenario(periods:)
+    operation =
+      lambda do
+        rate = Finrb::Rate.new(0.045, :apr, duration: periods)
+        Finrb::Amortization.new(250_000, rate)
+      end
+    residual =
+      lambda do |amortization|
+        reconciliations =
+          amortization.schedule.map do |entry|
+            (entry.opening_balance + entry.interest + entry.payment - entry.closing_balance).abs
+          end
+        reconciliations.max || Flt::DecNum(0)
+      end
+
+    Scenario.new("amortization/#{periods}", operation, residual)
+  end
+
+  def scenarios(seed:)
+    random = Random.new(seed)
+    [
+      solver_scenario(kind: :irr, size: 10, rate: Flt::DecNum('0.1'), guess: Flt::DecNum('0.05'), random:),
+      solver_scenario(kind: :irr, size: 120, rate: Flt::DecNum('-0.02'), guess: Flt::DecNum('0.1'), random:),
+      solver_scenario(kind: :irr, size: 1000, rate: Flt::DecNum('0.03'), guess: Flt::DecNum('0.1'), random:),
+      solver_scenario(kind: :irr, size: 30, rate: Flt::DecNum('2.5'), guess: Flt::DecNum('0.1'), random:),
+      solver_scenario(kind: :xirr, size: 12, rate: Flt::DecNum('0.08'), guess: Flt::DecNum('0.1'), random:),
+      solver_scenario(kind: :xirr, size: 250, rate: Flt::DecNum('-0.01'), guess: Flt::DecNum('0.1'), random:),
+      amortization_scenario(periods: 120),
+      amortization_scenario(periods: 360),
+      amortization_scenario(periods: 600)
+    ]
+  end
+
+  def verify(scenarios)
+    puts('Correctness preflight:')
+    scenarios.each do |scenario|
+      reset_evaluations
+      result = scenario.operation.call
+      objective_evaluations = evaluations
+      residual = scenario.residual.call(result)
+      raise(VerificationError, "#{scenario.name} residual #{residual} exceeds #{MAX_NORMALIZED_RESIDUAL}") if residual > MAX_NORMALIZED_RESIDUAL
+
+      evaluation_text = objective_evaluations.positive? ? " evaluations=#{objective_evaluations}" : ''
+      puts("  #{scenario.name}: residual=#{residual}#{evaluation_text}")
+    end
+  end
+
+  def run(argv)
+    options = { time: 2, warmup: 1, seed: 20_260_826 }
+    parser =
+      OptionParser.new do |options_parser|
+        options_parser.on('--time SECONDS', Integer) { |value| options[:time] = value }
+        options_parser.on('--warmup SECONDS', Integer) { |value| options[:warmup] = value }
+        options_parser.on('--seed SEED', Integer) { |value| options[:seed] = value }
+      end
+    parser.parse!(argv)
+    raise(ArgumentError, 'time must be positive') unless options[:time].positive?
+    raise(ArgumentError, 'warmup must be non-negative') if options[:warmup].negative?
+
+    Finrb::Cashflow.prepend(EvaluationCounter)
+    benchmark_scenarios = scenarios(seed: options[:seed])
+    puts("ruby=#{RUBY_ENGINE} #{RUBY_VERSION} seed=#{options[:seed]}")
+    verify(benchmark_scenarios)
+
+    Benchmark.ips do |benchmark|
+      benchmark.config(time: options[:time], warmup: options[:warmup])
+      benchmark_scenarios.each do |scenario|
+        benchmark.report(scenario.name, &scenario.operation)
+      end
+      benchmark.compare!
+    end
+  end
+end
+
+FinrbBenchmark.run(ARGV)

--- a/script/benchmark_finrb.rb
+++ b/script/benchmark_finrb.rb
@@ -7,7 +7,7 @@ require_relative('../lib/finrb')
 
 # Deterministic benchmark scenarios and correctness preflight for finrb.
 module FinrbBenchmark
-  Scenario = Data.define(:name, :operation, :residual)
+  Scenario = Data.define(:family, :name, :operation, :expected, :residual, :residual_name)
   class VerificationError < StandardError; end
   MAX_NORMALIZED_RESIDUAL = Flt::DecNum('1e-12')
   private_constant :Scenario, :VerificationError, :MAX_NORMALIZED_RESIDUAL
@@ -75,7 +75,14 @@ module FinrbBenchmark
         result.respond_to?(:effective) ? result.effective : result
       end
 
-    Scenario.new("#{kind}/#{size}", operation, ->(result) { normalized_residual(cashflows, result, residual_function) })
+    Scenario.new(
+      kind,
+      "#{kind}/#{size}",
+      operation,
+      rate,
+      ->(result) { normalized_residual(cashflows, result, residual_function) },
+      'normalized equation residual'
+    )
   end
 
   def amortization_scenario(periods:)
@@ -93,7 +100,7 @@ module FinrbBenchmark
         reconciliations.max || Flt::DecNum(0)
       end
 
-    Scenario.new("amortization/#{periods}", operation, residual)
+    Scenario.new(:amortization, "amortization/#{periods}", operation, nil, residual, 'schedule reconciliation error')
   end
 
   def scenarios(seed:)
@@ -118,10 +125,25 @@ module FinrbBenchmark
       result = scenario.operation.call
       objective_evaluations = evaluations
       residual = scenario.residual.call(result)
-      raise(VerificationError, "#{scenario.name} residual #{residual} exceeds #{MAX_NORMALIZED_RESIDUAL}") if residual > MAX_NORMALIZED_RESIDUAL
+      raise(VerificationError, "#{scenario.name} #{scenario.residual_name} #{residual} exceeds #{MAX_NORMALIZED_RESIDUAL}") if residual > MAX_NORMALIZED_RESIDUAL
+
+      root_error = scenario.expected && (result - scenario.expected).abs
+      raise(VerificationError, "#{scenario.name} known-root error #{root_error} exceeds #{MAX_NORMALIZED_RESIDUAL}") if root_error && root_error > MAX_NORMALIZED_RESIDUAL
 
       evaluation_text = objective_evaluations.positive? ? " evaluations=#{objective_evaluations}" : ''
-      puts("  #{scenario.name}: residual=#{residual}#{evaluation_text}")
+      root_text = root_error ? " known_root_error=#{root_error}" : ''
+      puts("  #{scenario.name}: #{scenario.residual_name}=#{residual}#{root_text}#{evaluation_text}")
+    end
+  end
+
+  def benchmark_family(family, scenarios, time:, warmup:)
+    puts("\n#{family.to_s.upcase} performance (compare only against the same scenario across runs):")
+    Benchmark.ips do |benchmark|
+      benchmark.config(time:, warmup:)
+      scenarios.each do |scenario|
+        benchmark.report(scenario.name, &scenario.operation)
+      end
+      benchmark.compare!
     end
   end
 
@@ -141,13 +163,10 @@ module FinrbBenchmark
     benchmark_scenarios = scenarios(seed: options[:seed])
     puts("ruby=#{RUBY_ENGINE} #{RUBY_VERSION} seed=#{options[:seed]}")
     verify(benchmark_scenarios)
+    puts('External solver agreement is verified separately with: rake solver:verify')
 
-    Benchmark.ips do |benchmark|
-      benchmark.config(time: options[:time], warmup: options[:warmup])
-      benchmark_scenarios.each do |scenario|
-        benchmark.report(scenario.name, &scenario.operation)
-      end
-      benchmark.compare!
+    benchmark_scenarios.group_by(&:family).each do |family, family_scenarios|
+      benchmark_family(family, family_scenarios, time: options[:time], warmup: options[:warmup])
     end
   end
 end

--- a/script/verify_markdown_examples.rb
+++ b/script/verify_markdown_examples.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+
+root = File.expand_path('..', __dir__)
+paths = ARGV.empty? ? [File.join(root, 'docs', 'api.md')] : ARGV.map { |path| File.expand_path(path, root) }
+marker = '<!-- verify-example -->'
+pattern = /#{Regexp.escape(marker)}\s*```ruby\s*\n(.*?)^```/m
+failures = []
+verified = 0
+
+paths.each do |path|
+  source = File.read(path)
+  examples = source.scan(pattern).flatten
+  markers = source.scan(marker).length
+  failures << "#{path}: found #{markers} markers but #{examples.length} executable Ruby blocks" if markers != examples.length
+
+  examples.each_with_index do |example, index|
+    command = [RbConfig.ruby, "-I#{File.join(root, 'lib')}", '-rfinrb', '-rdate', '-e', example]
+    stdout, stderr, status = Open3.capture3(*command, chdir: root)
+    verified += 1
+    next if status.success?
+
+    failures << <<~MESSAGE
+      #{path}: verified example #{index + 1} failed
+      #{stdout}#{stderr}
+    MESSAGE
+  end
+end
+
+if failures.empty?
+  puts("Verified #{verified} Markdown examples")
+else
+  warn(failures.join("\n"))
+  exit(1)
+end

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -150,7 +150,7 @@ module Finrb
   end
 
   module TVM
-    def self.discount_rate: (n: number, pv: number, fv: number, pmt: number, ?type: Integer, ?lower: number, ?upper: number) -> decimal
+    def self.discount_rate: (n: number, pv: number, fv: number, pmt: number, ?type: Integer, ?guess: number?, ?lower: number?, ?upper: number?) -> decimal
     def self.fv: (r: number, n: number, ?pv: number, ?pmt: number, ?type: Integer) -> decimal
     def self.fv_annuity: (r: number, n: number, pmt: number, ?type: Integer) -> decimal
     def self.fv_simple: (r: number, n: number, pv: number) -> decimal

--- a/sig/finrb.rbs
+++ b/sig/finrb.rbs
@@ -169,7 +169,7 @@ module Finrb
   module Accounting
     type inventory_result = { cost_of_goods: decimal, ending_inventory: decimal }
 
-    def self.cogs: (uinv: number, pinv: number, units: number | numbers, price: number | numbers, sinv: number, ?method: String) -> inventory_result
+    def self.cogs: (uinv: number, pinv: number, units: number | numbers | nil, price: number | numbers | nil, sinv: number, ?method: String | Symbol) -> inventory_result
     def self.ddb: (cost: number, rv: number, t: Integer) -> { t: Array[Integer], ddb: Array[decimal] }
     def self.slde: (cost: number, rv: number, t: number) -> decimal
   end

--- a/spec/finrb/accounting_spec.rb
+++ b/spec/finrb/accounting_spec.rb
@@ -50,6 +50,13 @@ describe(Finrb::Accounting) do
       expect(result).to(eq(cost_of_goods: D(10), ending_inventory: D(44)))
     end
 
+    it('retains every earlier layer when a LIFO sale ends in the second purchase layer') do
+      result = Accounting.cogs(uinv: 2, pinv: 2, units: [3, 5], price: [3, 5], sinv: 2, method: 'LIFO')
+
+      expect(result).to(eq(cost_of_goods: D(10), ending_inventory: D(28)))
+      expect(result.values.sum).to(eq(D(38)))
+    end
+
     it('uses beginning inventory after exhausting LIFO purchase layers') do
       result = Accounting.cogs(uinv: 2, pinv: 2, units: [3, 5], price: [3, 5], sinv: 9, method: 'LIFO')
 
@@ -67,13 +74,22 @@ describe(Finrb::Accounting) do
 
       %w[FIFO LIFO WAC].each do |method|
         expect { Accounting.cogs(**arguments, method:) }
-          .to(raise_error(Finrb::Error, /Inventory is not enough/))
+          .to(raise_error(Finrb::DomainError, /inventory is insufficient/i))
       end
     end
 
     it('rejects mismatched purchase layers') do
       expect { Accounting.cogs(uinv: 1, pinv: 2, units: [1], price: [], sinv: 1) }
-        .to(raise_error(Finrb::Error, /length/))
+        .to(raise_error(ArgumentError, /equal lengths/))
+    end
+
+    it('rejects unknown methods and invalid inventory values') do
+      expect { Accounting.cogs(uinv: 1, pinv: 2, units: [], price: [], sinv: 0, method: 'AVERAGE') }
+        .to(raise_error(ArgumentError, /FIFO, LIFO, or WAC/))
+      expect { Accounting.cogs(uinv: -1, pinv: 2, units: [], price: [], sinv: 0) }
+        .to(raise_error(ArgumentError, /beginning inventory units/))
+      expect { Accounting.cogs(uinv: 0, pinv: 0, units: [], price: [], sinv: 0, method: 'WAC') }
+        .not_to(raise_error)
     end
   end
 
@@ -96,7 +112,14 @@ describe(Finrb::Accounting) do
     it('stops immediately at residual value and rejects short useful lives') do
       expect(Accounting.ddb(cost: 1200, rv: 800, t: 2)[:ddb]).to(eq([D(400), D(0)]))
       expect { Accounting.ddb(cost: 1200, rv: 200, t: 1) }
-        .to(raise_error(Finrb::Error, /larger than 1/))
+        .to(raise_error(Finrb::DomainError, /at least 2 periods/))
+    end
+
+    it('requires an integer useful life and a valid residual value') do
+      expect { Accounting.ddb(cost: 1200, rv: 200, t: 2.5) }
+        .to(raise_error(ArgumentError, /useful life must be a positive integer/))
+      expect { Accounting.ddb(cost: 1200, rv: 1300, t: 5) }
+        .to(raise_error(Finrb::DomainError, /must not exceed asset cost/))
     end
   end
 
@@ -105,6 +128,15 @@ describe(Finrb::Accounting) do
       res = Accounting.slde(cost: 1200, rv: 200, t: 5)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('200')))
+    end
+
+    it('requires a positive useful life and valid finite values') do
+      expect { Accounting.slde(cost: 1200, rv: 200, t: 0) }
+        .to(raise_error(Finrb::DomainError, /useful life must be greater than zero/))
+      expect { Accounting.slde(cost: Float::INFINITY, rv: 200, t: 5) }
+        .to(raise_error(ArgumentError, /asset cost must be finite/))
+      expect { Accounting.slde(cost: 1200, rv: 1300, t: 5) }
+        .to(raise_error(Finrb::DomainError, /must not exceed asset cost/))
     end
   end
 end

--- a/spec/finrb/amortization_spec.rb
+++ b/spec/finrb/amortization_spec.rb
@@ -318,7 +318,7 @@ describe(Finrb::Amortization) do
 
     it('validates fee amount and financing mode') do
       expect { Amortization.new(1000, rate, origination_fee: -1) }
-        .to(raise_error(ArgumentError, /origination_fee must be non-negative/))
+        .to(raise_error(ArgumentError, /origination fee must be greater than or equal to zero/))
       expect { Amortization.new(1000, rate, origination_fee: 1000) }
         .to(raise_error(ArgumentError, /less than principal/))
       expect { Amortization.new(1000, rate, finance_origination_fee: :yes) }

--- a/spec/finrb/ratios_spec.rb
+++ b/spec/finrb/ratios_spec.rb
@@ -7,6 +7,13 @@ describe(Finrb::Ratios) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('2.5')))
     end
+
+    it('requires finite inputs and non-zero current liabilities') do
+      expect { Ratios.cash_ratio(cash: Float::INFINITY, ms: 0, cl: 1) }
+        .to(raise_error(ArgumentError, /cash must be finite/))
+      expect { Ratios.cash_ratio(cash: 1, ms: 0, cl: 0) }
+        .to(raise_error(Finrb::DomainError, /current liabilities must be non-zero/))
+    end
   end
 
   describe('current_ratio') do
@@ -49,6 +56,15 @@ describe(Finrb::Ratios) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.4654545')))
     end
+
+    it('validates share counts and tax rates') do
+      expect { Ratios.diluted_eps(ni: 100, pd: 0, w: 0) }
+        .to(raise_error(Finrb::DomainError, /weighted average common shares/))
+      expect { Ratios.diluted_eps(ni: 100, pd: 0, w: 100, tax: 1.1) }
+        .to(raise_error(ArgumentError, /tax rate must be between 0 and 1/))
+      expect { Ratios.diluted_eps(ni: 100, pd: 0, w: 100, cds: -1) }
+        .to(raise_error(ArgumentError, /convertible debt shares/))
+    end
   end
 
   describe('eps') do
@@ -56,6 +72,11 @@ describe(Finrb::Ratios) do
       res = Ratios.eps(ni: 10_000, pd: 1000, w: 11_000)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.8181818')))
+    end
+
+    it('requires positive weighted average shares') do
+      expect { Ratios.eps(ni: 10_000, pd: 1000, w: 0) }
+        .to(raise_error(Finrb::DomainError, /weighted average common shares/))
     end
   end
 
@@ -84,7 +105,7 @@ describe(Finrb::Ratios) do
 
     it('rejects options that are not in the money') do
       expect { Ratios.iss(amp: 15, ep: 15, n: 10_000) }
-        .to(raise_error(Finrb::Error, /amp must larger/))
+        .to(raise_error(Finrb::DomainError, /market price must be greater than exercise price/))
     end
   end
 
@@ -139,12 +160,36 @@ describe(Finrb::Ratios) do
 
     it('rejects mismatched share and month vectors') do
       expect { Ratios.was(ns: [100], nm: []) }
-        .to(raise_error(Finrb::Error, /must be equal/))
+        .to(raise_error(ArgumentError, /must have equal lengths/))
     end
 
     it('accepts scalar and empty share histories') do
       expect(Ratios.was(ns: 100, nm: 12)).to(eq(D(100)))
       expect(Ratios.was(ns: nil, nm: nil)).to(eq(0))
+    end
+
+    it('validates share changes and months outstanding') do
+      expect { Ratios.was(ns: ['100'], nm: [12]) }
+        .to(raise_error(ArgumentError, /share change must be numeric/))
+      expect { Ratios.was(ns: [100], nm: [13]) }
+        .to(raise_error(ArgumentError, /months outstanding must be between 0 and 12/))
+    end
+  end
+
+  describe('denominator validation') do
+    {
+      current_ratio: -> { Ratios.current_ratio(ca: 1, cl: 0) },
+      debt_ratio: -> { Ratios.debt_ratio(td: 1, ta: 0) },
+      financial_leverage: -> { Ratios.financial_leverage(te: 0, ta: 1) },
+      gpm: -> { Ratios.gpm(gp: 1, rv: 0) },
+      lt_d2e: -> { Ratios.lt_d2e(ltd: 1, te: 0) },
+      npm: -> { Ratios.npm(ni: 1, rv: 0) },
+      quick_ratio: -> { Ratios.quick_ratio(cash: 1, ms: 0, rc: 0, cl: 0) },
+      total_d2e: -> { Ratios.total_d2e(td: 1, te: 0) }
+    }.each do |name, calculation|
+      it("rejects a zero denominator for #{name}") do
+        expect(&calculation).to(raise_error(Finrb::DomainError, /must be non-zero/))
+      end
     end
   end
 end

--- a/spec/finrb/returns_spec.rb
+++ b/spec/finrb/returns_spec.rb
@@ -21,19 +21,19 @@ describe(Finrb::Returns) do
 
     it('requires a positive beginning value') do
       expect { Returns.cagr(beginning_value: 0, ending_value: 100, periods: 2) }
-        .to(raise_error(ArgumentError, /beginning_value must be greater than zero/))
+        .to(raise_error(ArgumentError, /beginning value must be greater than zero/))
     end
 
     it('rejects a negative ending value') do
       expect { Returns.cagr(beginning_value: 100, ending_value: -1, periods: 2) }
-        .to(raise_error(ArgumentError, /ending_value must be greater than or equal to zero/))
+        .to(raise_error(ArgumentError, /ending value must be greater than or equal to zero/))
     end
 
     it('requires a positive integer number of periods') do
       expect { Returns.cagr(beginning_value: 100, ending_value: 110, periods: 0) }
-        .to(raise_error(ArgumentError, /periods must be a positive integer/))
+        .to(raise_error(ArgumentError, /period count must be a positive integer/))
       expect { Returns.cagr(beginning_value: 100, ending_value: 110, periods: 1.5) }
-        .to(raise_error(ArgumentError, /periods must be a positive integer/))
+        .to(raise_error(ArgumentError, /period count must be a positive integer/))
     end
   end
 

--- a/spec/finrb/returns_spec.rb
+++ b/spec/finrb/returns_spec.rb
@@ -129,6 +129,13 @@ describe(Finrb::Returns) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.3846154')))
     end
+
+    it('requires a non-negative deviation and non-zero average') do
+      expect { Returns.coefficient_variation(sd: -0.1, avg: 1) }
+        .to(raise_error(ArgumentError, /standard deviation/))
+      expect { Returns.coefficient_variation(sd: 0.1, avg: 0) }
+        .to(raise_error(Finrb::DomainError, /Average must be non-zero/))
+    end
   end
 
   describe('geometric_mean') do
@@ -141,6 +148,13 @@ describe(Finrb::Returns) do
     it('accepts a single return') do
       expect(Returns.geometric_mean(r: 0.1)).to(eq(D('0.1')))
     end
+
+    it('rejects empty observations and returns below a total loss') do
+      expect { Returns.geometric_mean(r: []) }
+        .to(raise_error(ArgumentError, /cannot be empty/))
+      expect { Returns.geometric_mean(r: [-1.01, 0.1]) }
+        .to(raise_error(Finrb::DomainError, /greater than or equal to -1/))
+    end
   end
 
   describe('harmonic_mean') do
@@ -149,6 +163,13 @@ describe(Finrb::Returns) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('8.92562')))
     end
+
+    it('requires positive prices') do
+      expect { Returns.harmonic_mean(p: []) }
+        .to(raise_error(ArgumentError, /cannot be empty/))
+      expect { Returns.harmonic_mean(p: [8, 0]) }
+        .to(raise_error(Finrb::DomainError, /Prices must be greater than zero/))
+    end
   end
 
   describe('hpr') do
@@ -156,6 +177,11 @@ describe(Finrb::Returns) do
       res = Returns.hpr(ev: 33, bv: 30, cfr: 0.5)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.1166667')))
+    end
+
+    it('requires a positive beginning value') do
+      expect { Returns.hpr(ev: 33, bv: 0) }
+        .to(raise_error(Finrb::DomainError, /beginning value must be greater than zero/))
     end
   end
 
@@ -173,6 +199,11 @@ describe(Finrb::Returns) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.5')))
     end
+
+    it('requires positive standard deviation') do
+      expect { Returns.sf_ratio(rp: 0.09, rl: 0.03, sd: 0) }
+        .to(raise_error(Finrb::DomainError, /standard deviation must be greater than zero/))
+    end
   end
 
   describe('sharpe_ratio') do
@@ -180,6 +211,11 @@ describe(Finrb::Returns) do
       res = Returns.sharpe_ratio(rp: 0.038, rf: 0.015, sd: 0.07)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.3285714')))
+    end
+
+    it('requires positive standard deviation') do
+      expect { Returns.sharpe_ratio(rp: 0.038, rf: 0.015, sd: 0) }
+        .to(raise_error(Finrb::DomainError, /standard deviation must be greater than zero/))
     end
   end
 
@@ -192,7 +228,14 @@ describe(Finrb::Returns) do
 
     it('rejects mismatched valuation periods') do
       expect { Returns.twrr(ev: [120], bv: [100, 110], cfr: [2]) }
-        .to(raise_error(Finrb::Error, /Different number/))
+        .to(raise_error(ArgumentError, /must have equal lengths/))
+    end
+
+    it('rejects empty periods and invalid wealth relatives') do
+      expect { Returns.twrr(ev: [], bv: [], cfr: []) }
+        .to(raise_error(ArgumentError, /cannot be empty/))
+      expect { Returns.twrr(ev: [-2], bv: [1], cfr: [0]) }
+        .to(raise_error(Finrb::DomainError, /wealth relative/))
     end
   end
 
@@ -201,6 +244,13 @@ describe(Finrb::Returns) do
       res = Returns.wpr(r: [0.12, 0.07, 0.03], w: [0.5, 0.4, 0.1])
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.091')))
+    end
+
+    it('requires aligned observations and fully allocated weights') do
+      expect { Returns.wpr(r: [0.1], w: [0.5, 0.5]) }
+        .to(raise_error(ArgumentError, /must have equal lengths/))
+      expect { Returns.wpr(r: [0.1, 0.2], w: [0.4, 0.5]) }
+        .to(raise_error(ArgumentError, /Weights must sum to 1/))
     end
   end
 end

--- a/spec/finrb/tvm_spec.rb
+++ b/spec/finrb/tvm_spec.rb
@@ -25,7 +25,7 @@ describe(Finrb::TVM) do
 
     it('validates explicit bounds') do
       expect { TVM.discount_rate(n: 1, pv: -100, fv: 90, pmt: 0, lower: 0, upper: -0.2) }
-        .to(raise_error(ArgumentError, /lower must be less/))
+        .to(raise_error(ArgumentError, /lower rate bound must be less than upper rate bound/))
     end
   end
 
@@ -243,27 +243,27 @@ describe(Finrb::TVM) do
   describe('public input validation') do
     it('rejects non-numeric and non-finite inputs') do
       expect { TVM.fv_simple(r: Float::NAN, n: 2, pv: 100) }
-        .to(raise_error(ArgumentError, /r must be finite/))
+        .to(raise_error(ArgumentError, /periodic rate must be finite/))
       expect { TVM.pv_simple(r: 0.1, n: Float::INFINITY, fv: 100) }
-        .to(raise_error(ArgumentError, /n must be finite/))
+        .to(raise_error(ArgumentError, /period count must be finite/))
       expect { TVM.fv_annuity(r: 0.1, n: 2, pmt: '100') }
-        .to(raise_error(ArgumentError, /pmt must be numeric/))
+        .to(raise_error(ArgumentError, /payment must be numeric/))
     end
 
     it('rejects invalid rates and periods') do
       expect { TVM.fv_simple(r: -1, n: 2, pv: 100) }
         .to(raise_error(Finrb::DomainError, /greater than -1/))
       expect { TVM.pv_simple(r: 0.1, n: -1, fv: 100) }
-        .to(raise_error(Finrb::DomainError, /non-negative/))
+        .to(raise_error(Finrb::DomainError, /period count must be greater than or equal to zero/))
     end
 
     it('rejects invalid payment types and cashflows') do
       expect { TVM.fv(r: 0.1, n: 2, type: 2) }
-        .to(raise_error(ArgumentError, /type must be 0 or 1/))
+        .to(raise_error(ArgumentError, /payment timing type must be 0 \(end\) or 1 \(beginning\)/))
       expect { TVM.npv(r: 0.1, cf: []) }
-        .to(raise_error(ArgumentError, /cf cannot be empty/))
+        .to(raise_error(ArgumentError, /cashflows cannot be empty/))
       expect { TVM.pv_uneven(r: 0.1, cf: []) }
-        .to(raise_error(ArgumentError, /cf cannot be empty/))
+        .to(raise_error(ArgumentError, /cashflows cannot be empty/))
     end
 
     it('reports undefined perpetuity inputs') do

--- a/spec/finrb/tvm_spec.rb
+++ b/spec/finrb/tvm_spec.rb
@@ -7,6 +7,26 @@ describe(Finrb::TVM) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.0912806')))
     end
+
+    it('finds exact zero and negative rates') do
+      expect(TVM.discount_rate(n: 1, pv: -100, fv: 100, pmt: 0)).to(eq(D('0')))
+      expect(TVM.discount_rate(n: 1, pv: -100, fv: 90, pmt: 0)).to(be_within(D('1e-14')).of(D('-0.1')))
+    end
+
+    it('accepts an explicit valid bracket') do
+      result = TVM.discount_rate(n: 1, pv: -100, fv: 90, pmt: 0, lower: -0.2, upper: 0)
+
+      expect(result).to(be_within(D('1e-14')).of(D('-0.1')))
+    end
+
+    it('preserves the default opposite bound when overriding one bound') do
+      expect(TVM.discount_rate(n: 1, pv: -100, fv: 90, pmt: 0, lower: -0.2)).to(be_within(D('1e-14')).of(D('-0.1')))
+    end
+
+    it('validates explicit bounds') do
+      expect { TVM.discount_rate(n: 1, pv: -100, fv: 90, pmt: 0, lower: 0, upper: -0.2) }
+        .to(raise_error(ArgumentError, /lower must be less/))
+    end
   end
 
   describe('fv') do
@@ -28,6 +48,11 @@ describe(Finrb::TVM) do
       res = TVM.fv_annuity(r: 0.03, n: 12, pmt: -1000, type: 1)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('14617.79044')))
+    end
+
+    it('uses the zero-rate mathematical limit') do
+      expect(TVM.fv_annuity(r: 0, n: 12, pmt: -100)).to(eq(D('1200')))
+      expect(TVM.fv_annuity(r: 0, n: 12, pmt: -100, type: 1)).to(eq(D('1200')))
     end
   end
 
@@ -65,6 +90,15 @@ describe(Finrb::TVM) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('49.13733')))
     end
+
+    it('solves the zero-rate linear case') do
+      expect(TVM.n_period(r: 0, pv: -1000, fv: 0, pmt: 100)).to(eq(D('10')))
+    end
+
+    it('rejects an indeterminate zero-rate case') do
+      expect { TVM.n_period(r: 0, pv: -1000, fv: 1000, pmt: 0) }
+        .to(raise_error(Finrb::DomainError, /pmt must be non-zero/))
+    end
   end
 
   describe('npv') do
@@ -93,6 +127,15 @@ describe(Finrb::TVM) do
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('137.3511')))
     end
+
+    it('uses the zero-rate mathematical limit') do
+      expect(TVM.pmt(r: 0, n: 12, pv: -1200, fv: 0)).to(eq(D('100')))
+    end
+
+    it('rejects a zero payment period count') do
+      expect { TVM.pmt(r: 0.1, n: 0, pv: -1000, fv: 0) }
+        .to(raise_error(Finrb::DomainError, /greater than zero/))
+    end
   end
 
   describe('pv') do
@@ -120,6 +163,11 @@ describe(Finrb::TVM) do
       res = TVM.pv_annuity(r: 0.0425, n: 3, pmt: 30_000)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('-82859.27543')))
+    end
+
+    it('uses the zero-rate mathematical limit') do
+      expect(TVM.pv_annuity(r: 0, n: 12, pmt: 100)).to(eq(D('-1200')))
+      expect(TVM.pv_annuity(r: 0, n: 12, pmt: 100, type: 1)).to(eq(D('-1200')))
     end
   end
 
@@ -174,6 +222,55 @@ describe(Finrb::TVM) do
       res = TVM.r_perpetuity(pmt: 4.5, pv: -75)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.06')))
+    end
+  end
+
+  describe('financial invariants') do
+    it('round-trips present and future values at a negative rate') do
+      future = TVM.fv(r: -0.02, n: 12, pv: -1000)
+      present = TVM.pv(r: -0.02, n: 12, fv: -future)
+
+      expect(present).to(be_within(D('1e-20')).of(D('1000')))
+    end
+
+    it('reconstructs the target future value from the solved payment') do
+      payment = TVM.pmt(r: -0.02, n: 12, pv: -1000, fv: 0)
+
+      expect(TVM.fv(r: -0.02, n: 12, pv: -1000, pmt: payment)).to(be_within(D('1e-20')).of(D('0')))
+    end
+  end
+
+  describe('public input validation') do
+    it('rejects non-numeric and non-finite inputs') do
+      expect { TVM.fv_simple(r: Float::NAN, n: 2, pv: 100) }
+        .to(raise_error(ArgumentError, /r must be finite/))
+      expect { TVM.pv_simple(r: 0.1, n: Float::INFINITY, fv: 100) }
+        .to(raise_error(ArgumentError, /n must be finite/))
+      expect { TVM.fv_annuity(r: 0.1, n: 2, pmt: '100') }
+        .to(raise_error(ArgumentError, /pmt must be numeric/))
+    end
+
+    it('rejects invalid rates and periods') do
+      expect { TVM.fv_simple(r: -1, n: 2, pv: 100) }
+        .to(raise_error(Finrb::DomainError, /greater than -1/))
+      expect { TVM.pv_simple(r: 0.1, n: -1, fv: 100) }
+        .to(raise_error(Finrb::DomainError, /non-negative/))
+    end
+
+    it('rejects invalid payment types and cashflows') do
+      expect { TVM.fv(r: 0.1, n: 2, type: 2) }
+        .to(raise_error(ArgumentError, /type must be 0 or 1/))
+      expect { TVM.npv(r: 0.1, cf: []) }
+        .to(raise_error(ArgumentError, /cf cannot be empty/))
+      expect { TVM.pv_uneven(r: 0.1, cf: []) }
+        .to(raise_error(ArgumentError, /cf cannot be empty/))
+    end
+
+    it('reports undefined perpetuity inputs') do
+      expect { TVM.pv_perpetuity(r: 0.02, pmt: 100, g: 0.02) }
+        .to(raise_error(Finrb::DomainError, /Growth rate/))
+      expect { TVM.r_perpetuity(pmt: 100, pv: 0) }
+        .to(raise_error(Finrb::DomainError, /non-zero/))
     end
   end
 end

--- a/spec/finrb/validation_spec.rb
+++ b/spec/finrb/validation_spec.rb
@@ -9,6 +9,11 @@ describe(Finrb::Validation) do
       expect(described_class.decimal_at_least(-1, minimum: -1, name: 'rate')).to(eq(D(-1)))
     end
 
+    it('returns decimals validated against zero and ranges') do
+      expect(described_class.non_zero_decimal(-1, name: 'balance')).to(eq(D(-1)))
+      expect(described_class.decimal_between(1, minimum: 0, maximum: 1, name: 'fraction')).to(eq(D(1)))
+    end
+
     it('rejects values outside each bound') do
       expect { described_class.positive_decimal(0, name: 'amount') }
         .to(raise_error(ArgumentError, /amount must be greater than zero/))
@@ -18,6 +23,13 @@ describe(Finrb::Validation) do
         .to(raise_error(ArgumentError, /rate must be greater than -1/))
       expect { described_class.decimal_at_least(-2, minimum: -1, name: 'rate') }
         .to(raise_error(ArgumentError, /rate must be greater than or equal to -1/))
+    end
+
+    it('rejects zero and out-of-range decimals') do
+      expect { described_class.non_zero_decimal(0, name: 'balance') }
+        .to(raise_error(ArgumentError, /balance must be non-zero/))
+      expect { described_class.decimal_between(2, minimum: 0, maximum: 1, name: 'fraction') }
+        .to(raise_error(ArgumentError, /fraction must be between 0 and 1/))
     end
 
     it('allows callers to classify financial-domain errors') do

--- a/spec/finrb/validation_spec.rb
+++ b/spec/finrb/validation_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe(Finrb::Validation) do
+  describe('decimal bounds') do
+    it('returns validated decimals') do
+      expect(described_class.positive_decimal(2, name: 'amount')).to(eq(D(2)))
+      expect(described_class.non_negative_decimal(0, name: 'amount')).to(eq(D(0)))
+      expect(described_class.decimal_greater_than(0, minimum: -1, name: 'rate')).to(eq(D(0)))
+      expect(described_class.decimal_at_least(-1, minimum: -1, name: 'rate')).to(eq(D(-1)))
+    end
+
+    it('rejects values outside each bound') do
+      expect { described_class.positive_decimal(0, name: 'amount') }
+        .to(raise_error(ArgumentError, /amount must be greater than zero/))
+      expect { described_class.non_negative_decimal(-1, name: 'amount') }
+        .to(raise_error(ArgumentError, /amount must be greater than or equal to zero/))
+      expect { described_class.decimal_greater_than(-1, minimum: -1, name: 'rate') }
+        .to(raise_error(ArgumentError, /rate must be greater than -1/))
+      expect { described_class.decimal_at_least(-2, minimum: -1, name: 'rate') }
+        .to(raise_error(ArgumentError, /rate must be greater than or equal to -1/))
+    end
+
+    it('allows callers to classify financial-domain errors') do
+      expect { described_class.positive_decimal(0, name: 'term', error: Finrb::DomainError) }
+        .to(raise_error(Finrb::DomainError, /term must be greater than zero/))
+    end
+  end
+end

--- a/spec/finrb/yields_spec.rb
+++ b/spec/finrb/yields_spec.rb
@@ -112,7 +112,7 @@ describe(Finrb::Yields) do
 
     it('rejects unknown conversion types') do
       expect { Yields.eir(r: 0.05, type: 'unknown') }
-        .to(raise_error(Finrb::Error, /type must be/))
+        .to(raise_error(ArgumentError, /type must be/))
     end
   end
 
@@ -167,6 +167,45 @@ describe(Finrb::Yields) do
       res = Yields.r_norminal(rc: 0.03, m: 4)
       expect(res).to(be_an_instance_of(Flt::DecNum))
       expect(res).to(be_within(D('0.00001')).of(D('0.03011278')))
+    end
+  end
+
+  describe('input validation') do
+    it('rejects non-numeric and non-finite inputs') do
+      expect { Yields.ear(r: '0.05', m: 12) }
+        .to(raise_error(ArgumentError, /r must be numeric/))
+      expect { Yields.ear_continuous(r: Float::INFINITY) }
+        .to(raise_error(ArgumentError, /r must be finite/))
+    end
+
+    it('rejects non-positive terms, face values, and compounding frequencies') do
+      expect { Yields.bdy(d: 1, f: 0, t: 30) }
+        .to(raise_error(Finrb::DomainError, /f must be greater than zero/))
+      expect { Yields.hpr2mmy(hpr: 0.01, t: 0) }
+        .to(raise_error(Finrb::DomainError, /t must be greater than zero/))
+      expect { Yields.ear(r: 0.05, m: 0) }
+        .to(raise_error(Finrb::DomainError, /m must be greater than zero/))
+      expect { Yields.eir(r: 0.05, n: 1, p: 0) }
+        .to(raise_error(Finrb::DomainError, /p must be greater than zero/))
+    end
+
+    it('rejects invalid discount and return domains') do
+      expect { Yields.bdy2mmy(bdy: 3, t: 120) }
+        .to(raise_error(Finrb::DomainError, /positive purchase price/))
+      expect { Yields.ear2bey(ear: -1.01) }
+        .to(raise_error(Finrb::DomainError, /greater than or equal to -1/))
+      expect { Yields.hpr2ear(hpr: -1.01, t: 30) }
+        .to(raise_error(Finrb::DomainError, /greater than or equal to -1/))
+      expect { Yields.r_continuous(r: -4, m: 4) }
+        .to(raise_error(Finrb::DomainError, /compounding period/))
+    end
+
+    it('preserves valid negative returns and inverse conversions') do
+      expect(Yields.ear2hpr(ear: -0.1, t: 365)).to(be_within(D('1e-20')).of(D('-0.1')))
+
+      nominal = D('-0.08')
+      continuous = Yields.r_continuous(r: nominal, m: 12)
+      expect(Yields.r_norminal(rc: continuous, m: 12)).to(be_within(D('1e-20')).of(nominal))
     end
   end
 end

--- a/spec/finrb/yields_spec.rb
+++ b/spec/finrb/yields_spec.rb
@@ -173,20 +173,20 @@ describe(Finrb::Yields) do
   describe('input validation') do
     it('rejects non-numeric and non-finite inputs') do
       expect { Yields.ear(r: '0.05', m: 12) }
-        .to(raise_error(ArgumentError, /r must be numeric/))
+        .to(raise_error(ArgumentError, /stated annual rate must be numeric/))
       expect { Yields.ear_continuous(r: Float::INFINITY) }
-        .to(raise_error(ArgumentError, /r must be finite/))
+        .to(raise_error(ArgumentError, /stated annual rate must be finite/))
     end
 
     it('rejects non-positive terms, face values, and compounding frequencies') do
       expect { Yields.bdy(d: 1, f: 0, t: 30) }
-        .to(raise_error(Finrb::DomainError, /f must be greater than zero/))
+        .to(raise_error(Finrb::DomainError, /face value must be greater than zero/))
       expect { Yields.hpr2mmy(hpr: 0.01, t: 0) }
-        .to(raise_error(Finrb::DomainError, /t must be greater than zero/))
+        .to(raise_error(Finrb::DomainError, /time to maturity must be greater than zero/))
       expect { Yields.ear(r: 0.05, m: 0) }
-        .to(raise_error(Finrb::DomainError, /m must be greater than zero/))
+        .to(raise_error(Finrb::DomainError, /compounding periods must be greater than zero/))
       expect { Yields.eir(r: 0.05, n: 1, p: 0) }
-        .to(raise_error(Finrb::DomainError, /p must be greater than zero/))
+        .to(raise_error(Finrb::DomainError, /target compounding periods must be greater than zero/))
     end
 
     it('rejects invalid discount and return domains') do

--- a/spec/finrb_spec.rb
+++ b/spec/finrb_spec.rb
@@ -59,7 +59,7 @@ describe(Finrb) do
       current = described_class.config
 
       expect { described_class.configure { |config| config.eps = 0 } }
-        .to(raise_error(ArgumentError, /eps must be positive/))
+        .to(raise_error(ArgumentError, /solver tolerance must be positive/))
       expect(described_class.config).to(equal(current))
     end
 

--- a/spec/finrb_spec.rb
+++ b/spec/finrb_spec.rb
@@ -2,7 +2,7 @@
 
 describe(Finrb) do
   it('exposes the gem version') do
-    expect(described_class::VERSION).to(eq('1.1.0'))
+    expect(described_class::VERSION).to(eq('1.2.0'))
   end
 
   describe('decimal interoperability') do


### PR DESCRIPTION
## 1.2.0

### Validation and financial correctness

- Apply the shared finite-decimal validation contract across yields, returns,
  accounting, ratios, cashflows, rates, amortization, and TVM helpers.
- Replace abbreviated validation errors with descriptive financial terms such
  as period count, future value, face value, and compounding periods.
- Add explicit denominator, rate, share-count, inventory, useful-life, and
  residual-value domain checks while preserving valid decimal calculations and
  return types.
- Fix LIFO ending-inventory retention when a sale is satisfied by the second
  purchase layer, preserving inventory cost conservation.
- Reject invalid weighted-return vectors and replace the previous unsolicited
  weighted-portfolio warning with an explicit validation error.

### Development and project maintenance

- Add deterministic `benchmark:run` scenarios using `benchmark-ips` for IRR,
  XIRR, and amortization scaling, with known-root, equation-residual, solver
  evaluation, and schedule-reconciliation preflight diagnostics.
- Add contributor and security guidance, and link the project entry documents
  from the README.
- Include contributor and security documentation in packaged gem metadata.
